### PR TITLE
Update the tplink driver to follow xbos plug api

### DIFF
--- a/driver/tp-link-plugstrip/main.go
+++ b/driver/tp-link-plugstrip/main.go
@@ -56,31 +56,6 @@ func main() {
 		os.Exit(1)
 	}
 	svc := bwClient.RegisterService(baseURI+deviceName, "s.tplink.v0")
-	// relayIface := svc.RegisterInterface("0", "i.xbos.plug")
-	// relayIface.SubscribeSlot("state", func(msg *bw2.SimpleMessage) {
-	// 	po := msg.GetOnePODF(bw2.PODFBinaryActuation)
-	// 	if po == nil {
-	// 		fmt.Println("Received actuation command w/o proper PO type, dropping")
-	// 		return
-	// 	} else if len(po.GetContents()) < 1 {
-	// 		fmt.Println("Received actuation command with invalid PO, dropping")
-	// 		return
-	// 	}
-	//
-	// 	if po.GetContents()[0] == 0 {
-	// 		err = ps.SetRelayState(false)
-	// 		if err != nil {
-	// 			fmt.Println(err)
-	// 		}
-	// 	} else if po.GetContents()[0] == 1 {
-	// 		err = ps.SetRelayState(true)
-	// 		if err != nil {
-	// 			fmt.Println(err)
-	// 		}
-	// 	} else {
-	// 		fmt.Println("Actuation command contents must be 0x00 or 0x01, dropping")
-	// 	}
-	// })
 
 	xbosIface := svc.RegisterInterface("0", "i.xbos.plug")
 	xbosIface.SubscribeSlot("state", func(msg *bw2.SimpleMessage) {

--- a/driver/tp-link-plugstrip/plugstrip.go
+++ b/driver/tp-link-plugstrip/plugstrip.go
@@ -29,6 +29,7 @@ type PowerStats struct {
 	Current float64
 	Voltage float64
 	Power   float64
+	Total   float64
 }
 
 func NewPlugstrip(ip string) (*Plugstrip, error) {
@@ -136,11 +137,19 @@ func (ps *Plugstrip) GetPowerStats() (*PowerStats, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse power statistics: %v", err)
 	}
-
+	match = regexp.MustCompile(`\"total\":(\d+(\.\d+)?)`).FindStringSubmatch(response)
+	if match == nil {
+		return nil, fmt.Errorf("Power statistics did not include valid total value")
+	}
+	total, err := strconv.ParseFloat(match[1], 64)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse total statistics: %v", err)
+	}
 	return &PowerStats{
 		Current: current,
 		Voltage: voltage,
 		Power:   power,
+		Total:   total,
 	}, nil
 }
 


### PR DESCRIPTION
@jhkolb @gtfierro 

This updates the tplink driver to follow the new xbos interface (a breaking change for apps using the old s.powerup interface). It also exports cumulative measurements and correctly reports the state of the HS110 plug if it is changed from other apps (not through the driver).

Known problems:
does not poll and report the state of HS100 plugs. 