### PR TITLE
Fixing Time Stamp Issue

### DIFF
--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -143,12 +143,15 @@ func main() {
 				}
 				fmt.Printf("%s %+v\n", currentPelican.name, status)
 
-				po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(TSTAT_PO_DF), status)
-				if err != nil {
-					fmt.Printf("Failed to create msgpack PO: %v", err)
-					done <- true
+				// Nil status indicates there is no recently sufficient data
+				if status != nil {
+					po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(TSTAT_PO_DF), status)
+					if err != nil {
+						fmt.Printf("Failed to create msgpack PO: %v", err)
+						done <- true
+					}
+					currentIface.PublishSignal("info", po)
 				}
-				currentIface.PublishSignal("info", po)
 				time.Sleep(pollInt)
 			}
 		}()

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -38,9 +38,9 @@ func main() {
 	username := params.MustString("username")
 	password := params.MustString("password")
 	sitename := params.MustString("sitename")
-	location := params.MustString("location")
+	timezone := params.MustString("timezone")
 
-	pelicans, err := DiscoverPelicans(username, password, sitename, location)
+	pelicans, err := DiscoverPelicans(username, password, sitename, timezone)
 	if err != nil {
 		fmt.Printf("Failed to discover thermostats: %v\n", err)
 		os.Exit(1)

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -38,8 +38,9 @@ func main() {
 	username := params.MustString("username")
 	password := params.MustString("password")
 	sitename := params.MustString("sitename")
+	location := params.MustString("location")
 
-	pelicans, err := DiscoverPelicans(username, password, sitename)
+	pelicans, err := DiscoverPelicans(username, password, sitename, location)
 	if err != nil {
 		fmt.Printf("Failed to discover thermostats: %v\n", err)
 		os.Exit(1)

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/immesys/spawnpoint/spawnable"
-	"github.com/parnurzeal/gorequest"
 	bw2 "gopkg.in/immesys/bw2bind.v5"
 )
 
@@ -52,7 +51,7 @@ func main() {
 	password := params.MustString("password")
 	sitename := params.MustString("sitename")
 
-	timezone, zoneErr := getTimeZone(sitename, username, password)
+	timezone, zoneErr := GetTimeZone(sitename, username, password)
 	if zoneErr != nil {
 		fmt.Printf("Error retrieving time zone from sitename: %v\n", zoneErr)
 	}
@@ -174,26 +173,4 @@ func main() {
 		}()
 	}
 	<-done
-}
-
-func getTimeZone(sitename, username, password string) (string, error) {
-	target := fmt.Sprintf("https://%s.officeclimatecontrol.net/api.cgi", sitename)
-	resp, _, errs := gorequest.New().Get(target).
-		Param("username", username).
-		Param("password", password).
-		Param("request", "get").
-		Param("object", "Site").
-		Param("value", "timeZone;").
-		End()
-	if errs != nil {
-		return "", fmt.Errorf("Error retrieving object result from %s: %s", target, errs)
-	}
-	defer resp.Body.Close()
-	var result apiObject
-	dec := xml.NewDecoder(resp.Body)
-	if err := dec.Decode(&result); err != nil {
-		return "", fmt.Errorf("Failed to decode response XML: %v", err)
-	}
-	timezone := result.Attribute.Timezone
-	return timezone, nil
 }

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -143,7 +143,7 @@ func main() {
 				}
 				fmt.Printf("%s %+v\n", currentPelican.name, status)
 
-				// Nil status indicates there is no recently sufficient data
+				// Nil status indicates there is no sufficiently recent data
 				if status != nil {
 					po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(TSTAT_PO_DF), status)
 					if err != nil {

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/xml"
 	"fmt"
 	"os"
 	"strings"
@@ -26,17 +25,6 @@ type stateMsg struct {
 	Fan             *bool    `msgpack:"fan"`
 }
 
-// Object API Result Structs
-type apiObject struct {
-	XMLName   xml.Name    `xml:"result"`
-	Success   int         `xml:"success"`
-	Attribute apiTimezone `xml:"attribute"`
-}
-
-type apiTimezone struct {
-	Timezone string `xml:"timeZone"`
-}
-
 func main() {
 	bwClient := bw2.ConnectOrExit("")
 	bwClient.OverrideAutoChainTo(true)
@@ -51,12 +39,7 @@ func main() {
 	password := params.MustString("password")
 	sitename := params.MustString("sitename")
 
-	timezone, zoneErr := GetTimeZone(sitename, username, password)
-	if zoneErr != nil {
-		fmt.Printf("Error retrieving time zone from sitename: %v\n", zoneErr)
-	}
-
-	pelicans, err := DiscoverPelicans(username, password, sitename, timezone)
+	pelicans, err := DiscoverPelicans(username, password, sitename)
 	if err != nil {
 		fmt.Printf("Failed to discover thermostats: %v\n", err)
 		os.Exit(1)

--- a/driver/pelican/params.yml
+++ b/driver/pelican/params.yml
@@ -4,4 +4,4 @@ password: <pelican password>
 sitename: <pelican site name>
 name: <thermostat name>
 poll_interval: <status poll interval>
-location: <thermostat location>
+timezone: <IANA timezone> # Must Be Recognized IANA Timezone Format

--- a/driver/pelican/params.yml
+++ b/driver/pelican/params.yml
@@ -4,3 +4,4 @@ password: <pelican password>
 sitename: <pelican site name>
 name: <thermostat name>
 poll_interval: <status poll interval>
+location: <thermostat location>

--- a/driver/pelican/params.yml
+++ b/driver/pelican/params.yml
@@ -4,4 +4,3 @@ password: <pelican password>
 sitename: <pelican site name>
 name: <thermostat name>
 poll_interval: <status poll interval>
-timezone: <IANA timezone> # Must Be Recognized IANA Timezone Format

--- a/driver/pelican/pelican.go
+++ b/driver/pelican/pelican.go
@@ -84,7 +84,6 @@ type apiHistory struct {
 }
 
 // Miscellaneous Structs
-
 type pelicanStateParams struct {
 	HeatingSetpoint *float64
 	CoolingSetpoint *float64
@@ -191,8 +190,7 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 		}
 	}
 
-	// Thermostat History Object Request to retrieve time stamp
-	// Retrieves all time stamps from the past 4 hours
+	// Thermostat History Object Request to retrieve time stamps from past hour
 	timezone, timeErr := time.LoadLocation(pel.timezone)
 	if timeErr != nil {
 		return nil, fmt.Errorf("Invalid Timezone specified in pelican struct: %v\n", timeErr)

--- a/driver/pelican/pelican.go
+++ b/driver/pelican/pelican.go
@@ -45,7 +45,7 @@ type PelicanStatus struct {
 	Fan             bool    `msgpack:"fan"`
 	Mode            int32   `msgpack:"mode"`
 	State           int32   `msgpack:"state"`
-	Time            string  `msgpack:"time"`
+	Time            int64   `msgpack:"time"`
 }
 
 // Thermostat Object API Result Structs
@@ -80,7 +80,7 @@ type apiRecords struct {
 }
 
 type apiHistory struct {
-	TimeStamp string `xml:"timestamp"`
+	TimeStamp int `xml:"timestamp"`
 }
 
 // Miscellaneous Structs
@@ -223,7 +223,7 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 	if histResult.Success == 0 {
 		return nil, fmt.Errorf("Error retrieving thermostat status from %s: %s", respHist.Request.URL, histResult.Message)
 	}
-	if len(histResult.Records.History) <= 0 {
+	if len(histResult.Records.History) == 0 {
 		return nil, fmt.Errorf("Error: No timestamp records found in past %v from %s", diff, pel.target)
 	}
 	match := histResult.Records.History[len(histResult.Records.History)-1]

--- a/driver/pelican/pelican.go
+++ b/driver/pelican/pelican.go
@@ -349,3 +349,25 @@ func (pel *Pelican) ModifyState(params *pelicanStateParams) error {
 
 	return nil
 }
+
+func GetTimeZone(sitename, username, password string) (string, error) {
+	target := fmt.Sprintf("https://%s.officeclimatecontrol.net/api.cgi", sitename)
+	resp, _, errs := gorequest.New().Get(target).
+		Param("username", username).
+		Param("password", password).
+		Param("request", "get").
+		Param("object", "Site").
+		Param("value", "timeZone;").
+		End()
+	if errs != nil {
+		return "", fmt.Errorf("Error retrieving object result from %s: %s", target, errs)
+	}
+	defer resp.Body.Close()
+	var result apiObject
+	dec := xml.NewDecoder(resp.Body)
+	if err := dec.Decode(&result); err != nil {
+		return "", fmt.Errorf("Failed to decode response XML: %v", err)
+	}
+	timezone := result.Attribute.Timezone
+	return timezone, nil
+}

--- a/driver/pelican/pelican.go
+++ b/driver/pelican/pelican.go
@@ -223,14 +223,13 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 	}
 
 	if len(histResult.Records.History) == 0 {
-		//return nil, fmt.Errorf("Error: No timestamp records found in past %v from %s", diff, pel.target)
 		return nil, nil
 	}
 
 	// Converting string timeStamp to int64 format
 	match := histResult.Records.History[len(histResult.Records.History)-1]
-	timeString := match.TimeStamp + ":00Z"
-	timeInt, timeErr := time.Parse(time.RFC3339, timeString)
+	timeString := match.TimeStamp + ":00"
+	timeStruct, timeErr := time.Parse(time.RFC3339, timeString)
 	if timeErr != nil {
 		return nil, fmt.Errorf("Error parsing %v into Time struct", timeString)
 	}
@@ -244,7 +243,7 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 		Fan:             fanState,
 		Mode:            modeNameMappings[thermostat.System],
 		State:           thermState,
-		Time:            timeInt.UnixNano(),
+		Time:            timeStruct.UnixNano(),
 	}, nil
 }
 

--- a/driver/pelican/pelican.go
+++ b/driver/pelican/pelican.go
@@ -195,9 +195,9 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 	if timeErr != nil {
 		return nil, fmt.Errorf("Invalid Timezone specified in pelican struct: %v\n", timeErr)
 	}
-	diff := time.Now().Add(-1 * time.Hour)
+
 	endTime := time.Now().In(timezone).Format(time.RFC3339)
-	startTime := diff.In(timezone).Format(time.RFC3339)
+	startTime := time.Now().Add(-1 * time.Hour).In(timezone).Format(time.RFC3339)
 
 	respHist, _, errsHist := pel.req.Get(pel.target).
 		Param("username", pel.username).

--- a/driver/pelican/pelican.go
+++ b/driver/pelican/pelican.go
@@ -45,7 +45,7 @@ type PelicanStatus struct {
 	Fan             bool    `msgpack:"fan"`
 	Mode            int32   `msgpack:"mode"`
 	State           int32   `msgpack:"state"`
-	Time            string   `msgpack:"time"`
+	Time            string  `msgpack:"time"`
 }
 
 // Thermostat Object API Result Structs
@@ -70,19 +70,19 @@ type apiThermostat struct {
 // Thermostat History Object API Result Structs
 
 type apiResultHistory struct {
-	XMLName xml.Name `xml:"result"`
-	Success int      `xml:"success"`
-	Message string   `xml:"message"`
-	Records apiRecords  `xml:"ThermostatHistory"`
+	XMLName xml.Name   `xml:"result"`
+	Success int        `xml:"success"`
+	Message string     `xml:"message"`
+	Records apiRecords `xml:"ThermostatHistory"`
 }
 
 type apiRecords struct {
-	Name    string    `xml:"name"`
+	Name    string       `xml:"name"`
 	History []apiHistory `xml:"History"`
 }
 
 type apiHistory struct {
-	TimeStamp   string  `xml:"timestamp"`
+	TimeStamp string `xml:"timestamp"`
 }
 
 // Miscellaneous Structs
@@ -218,7 +218,7 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 	}
 
 	var histResult apiResultHistory
-  histDec := xml.NewDecoder(respHist.Body)
+	histDec := xml.NewDecoder(respHist.Body)
 	if histErr := histDec.Decode(&histResult); histErr != nil {
 		return nil, fmt.Errorf("Failed to decode response XML: %v", histErr)
 	}

--- a/driver/pelican/pelican.go
+++ b/driver/pelican/pelican.go
@@ -228,7 +228,7 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 
 	// Converting string timeStamp to int64 format
 	match := histResult.Records.History[len(histResult.Records.History)-1]
-	timeString := match.TimeStamp + ":00"
+	timeString := match.TimeStamp + ":00Z"
 	timeStruct, timeErr := time.Parse(time.RFC3339, timeString)
 	if timeErr != nil {
 		return nil, fmt.Errorf("Error parsing %v into Time struct", timeString)

--- a/driver/pelican/pelican.go
+++ b/driver/pelican/pelican.go
@@ -228,10 +228,9 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 
 	// Converting string timeStamp to int64 format
 	match := histResult.Records.History[len(histResult.Records.History)-1]
-	timeString := match.TimeStamp + ":00Z"
-	timeStruct, timeErr := time.Parse(time.RFC3339, timeString)
+	timestamp, timeErr := time.ParseInLocation("2006-01-02T15:04", match.TimeStamp, timezone)
 	if timeErr != nil {
-		return nil, fmt.Errorf("Error parsing %v into Time struct", timeString)
+		return nil, fmt.Errorf("Error parsing %v into Time struct: %v\n", match.TimeStamp, timeErr)
 	}
 
 	return &PelicanStatus{
@@ -243,7 +242,7 @@ func (pel *Pelican) GetStatus() (*PelicanStatus, error) {
 		Fan:             fanState,
 		Mode:            modeNameMappings[thermostat.System],
 		State:           thermState,
-		Time:            timeStruct.UnixNano(),
+		Time:            timestamp.UnixNano(),
 	}, nil
 }
 


### PR DESCRIPTION
The goal of this pull request is to replace the "time" field in the PelicanStatus struct with the time stamp of the most recent thermostat status update from the Pelican Web API. This way, users can tell if a Pelican thermostat is disconnected or communicating antiquated information.

The programmatic changes are listed as follows:
- Added “Location” field to params.yml file
- Added “Location” field to Pelican struct
- Added “Location” parameter to “NewPelican” and “DiscoverPelicans” functions and adjusted implementation slightly to create Pelican structs with location fields
- Added 3 new structs in pelican.go (apiResultHistory, apiRecords, apiHistory) to handle results of ThermostatHistory get request.
- Edited main.go so Spawnpoint requests user location and passes location as a parameter into DiscoverPelican function call
- Changed PelicanStatus struct’s “time” field to be a string, not int32 type
- Commenting to clarify what any new code is doing