### PR TITLE
Integrate DR and timezone fixes for Pelican driver

### DIFF
--- a/driver/pelican/demandResponse.go
+++ b/driver/pelican/demandResponse.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"time"
+)
+
+type DR_EVENT_STATUS int
+
+const (
+	DR_EVENT_STATUS_NOT_CONFIGURED DR_EVENT_STATUS = iota
+	DR_EVENT_STATUS_UNUSABLE
+	DR_EVENT_STATUS_INACTIVE
+	DR_EVENT_STATUS_ACTIVE
+)
+
+type DR_EVENT_TYPE int
+
+const (
+	DR_EVENT_TYPE_NO_EVENT DR_EVENT_TYPE = iota
+	DR_EVENT_TYPE_NORMAL
+	DR_EVENT_TYPE_MODERATE
+	DR_EVENT_TYPE_HIGH
+	DR_EVENT_TYPE_SPECIAL
+)
+
+type ADREventWrapperAPI struct {
+	Success int         `xml:"success"`
+	Message string      `xml:"message"`
+	Event   ADREventAPI `xml:"attribute"`
+}
+
+type ADREventAPI struct {
+	End    string `xml:"OpenADREventEnd"`
+	Start  string `xml:"OpenADREventStart"`
+	Status string `xml:"OpenADRStatus"`
+	Type   string `xml:"OpenADREventType"`
+}
+
+type ADREvent struct {
+	EventEnd   int64           `msgpack:"event_end"`
+	EventStart int64           `msgpack:"event_start"`
+	EventType  DR_EVENT_TYPE   `msgpack:"event_type"`
+	DRStatus   DR_EVENT_STATUS `msgpack:"dr_status"`
+	Time       int64           `msgpack:"time"`
+}
+
+func (pel *Pelican) TrackDREvent() (*ADREvent, error) {
+	resp, _, errs := pel.req.Get(pel.target).
+		Param("username", pel.username).
+		Param("password", pel.password).
+		Param("request", "get").
+		Param("object", "Site").
+		Param("value", "OpenADREventEnd;OpenADREventStart;OpenADRStatus;OpenADREventType").
+		End()
+
+	if errs != nil {
+		return nil, fmt.Errorf("Error retrieving thermostat demand-response status from %s: %v", pel.target, errs)
+	}
+
+	defer resp.Body.Close()
+	var result ADREventWrapperAPI
+	dec := xml.NewDecoder(resp.Body)
+	if err := dec.Decode(&result); err != nil {
+		return nil, fmt.Errorf("Failed to decode demand-response XML: %v", err)
+	}
+	if result.Success == 0 {
+		return nil, fmt.Errorf("Error retrieving thermostat demand-response status from %s: %s", resp.Request.URL, result.Message)
+	}
+
+	event := result.Event
+	var output ADREvent
+
+	// Convert ADR Start Time from String to Int
+	if startTime, startErr := DRTimeToUnix(event.Start, pel.timezone); startErr != nil {
+		return nil, fmt.Errorf("String to Unix Time Conversion Error: %v", startErr)
+	} else {
+		output.EventStart = startTime
+	}
+
+	// Convert ADR End Time from String to Int
+	if endTime, endErr := DRTimeToUnix(event.End, pel.timezone); endErr != nil {
+		return nil, fmt.Errorf("String to Unix Time Conversion Error: %v", endErr)
+	} else {
+		output.EventEnd = endTime
+	}
+
+	eventStatus, statusErr := GetEventStatus(event.Status)
+	if statusErr != nil {
+		return nil, fmt.Errorf("Event Status Error: %v", statusErr)
+	}
+	output.DRStatus = eventStatus
+
+	eventType, typeErr := GetEventType(event.Type)
+	if typeErr != nil {
+		return nil, fmt.Errorf("Event Type Error: %v", typeErr)
+	}
+	output.EventType = eventType
+
+	output.Time = time.Now().UnixNano()
+
+	return &output, nil
+}
+
+func DRTimeToUnix(DRTime string, timezone *time.Location) (int64, error) {
+	// Time field is empty or nil
+	if len(DRTime) == 0 {
+		return 0, nil
+	}
+
+	// Using Parse in Location to convert time string into correct time.Time value
+	outputTime, timeErr := time.ParseInLocation("2006-01-02T15:04", DRTime, timezone)
+	if timeErr != nil {
+		return 0, fmt.Errorf("Error parsing %v into Time struct: %v\n", DRTime, timeErr)
+	}
+
+	return outputTime.UnixNano(), nil
+}
+
+// Map Status to Corresponding Integer Value
+func GetEventStatus(eventStatus string) (DR_EVENT_STATUS, error) {
+	switch eventStatus {
+	case "Not Configured":
+		return DR_EVENT_STATUS_NOT_CONFIGURED, nil
+	case "Unusable":
+		return DR_EVENT_STATUS_UNUSABLE, nil
+	case "Inactive":
+		return DR_EVENT_STATUS_INACTIVE, nil
+	case "Active":
+		return DR_EVENT_STATUS_ACTIVE, nil
+	default:
+		return 0, fmt.Errorf("Event status not recognized")
+	}
+}
+
+// Map Event Type to Corresponding Integer Value
+func GetEventType(eventType string) (DR_EVENT_TYPE, error) {
+	switch eventType {
+	case "Normal":
+		return DR_EVENT_TYPE_NORMAL, nil
+	case "Moderate":
+		return DR_EVENT_TYPE_MODERATE, nil
+	case "High":
+		return DR_EVENT_TYPE_HIGH, nil
+	case "Special":
+		return DR_EVENT_TYPE_SPECIAL, nil
+	case "None":
+		return DR_EVENT_TYPE_NO_EVENT, nil
+	default:
+		return 0, fmt.Errorf("Event type not recognized")
+	}
+}

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 const TSTAT_PO_DF = "2.1.1.0"
+const DR_PO_DF = "2.1.1.9"
 
 type setpointsMsg struct {
 	HeatingSetpoint *float64 `msgpack:"heating_setpoint"`
@@ -52,14 +53,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	pollDrStr := params.MustString("poll_interval_dr")
+	pollDr, drErr := time.ParseDuration(pollDrStr)
+	if drErr != nil {
+		fmt.Printf("Invalid demand response poll interval specified: %v\n", drErr)
+		os.Exit(1)
+	}
+
 	service := bwClient.RegisterService(baseURI, "s.pelican")
 	tstatIfaces := make([]*bw2.Interface, len(pelicans))
+	drstatIfaces := make([]*bw2.Interface, len(pelicans))
 	for i, pelican := range pelicans {
 		name := strings.Replace(pelican.name, " ", "_", -1)
 		name = strings.Replace(name, "&", "_and_", -1)
 		name = strings.Replace(name, "'", "", -1)
 		fmt.Println("Transforming", pelican.name, "=>", name)
 		tstatIfaces[i] = service.RegisterInterface(name, "i.xbos.thermostat")
+		drstatIfaces[i] = service.RegisterInterface(name, "i.xbos.demand_response")
 
 		tstatIfaces[i].SubscribeSlot("setpoints", func(msg *bw2.SimpleMessage) {
 			po := msg.GetOnePODF(TSTAT_PO_DF)
@@ -133,6 +143,7 @@ func main() {
 	for i, pelican := range pelicans {
 		currentPelican := pelican
 		currentIface := tstatIfaces[i]
+		currentDRIface := drstatIfaces[i]
 		go func() {
 			for {
 				status, err := currentPelican.GetStatus()
@@ -149,6 +160,22 @@ func main() {
 				}
 				currentIface.PublishSignal("info", po)
 				time.Sleep(pollInt)
+			}
+		}()
+
+		go func() {
+			for {
+				if drStatus, drErr := currentPelican.TrackDREvent(); drErr != nil {
+					fmt.Printf("Failed to retrieve Pelican's DR status: %v\n", drErr)
+				} else if drStatus != nil {
+					fmt.Printf("%s DR Status: %+v\n", currentPelican.name, drStatus)
+					po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(DR_PO_DF), drStatus)
+					if err != nil {
+						fmt.Printf("Failed to create DR msgpack PO: %v", err)
+					}
+					currentDRIface.PublishSignal("info", po)
+				}
+				time.Sleep(pollDr)
 			}
 		}()
 	}

--- a/driver/pelican/params.yml
+++ b/driver/pelican/params.yml
@@ -4,3 +4,4 @@ password: <pelican password>
 sitename: <pelican site name>
 name: <thermostat name>
 poll_interval: <status poll interval>
+poll_interval_dr: <dr status poll interval>


### PR DESCRIPTION
This pull request encapsulates a few changes for the Pelican driver:
- @john-b-yang's demand response signal integration
- @john-b-yang's timezone parsing for Pelican
- @gtfierro altering #23 to make sure "now" timestamps are used.
- demand response signal is now complicit with the updated  DR event
  interface (https://github.com/SoftwareDefinedBuildings/XBOS/pull/62)