### PR TITLE
Pelican Multi-Stage Support

### DIFF
--- a/driver/pelican/README.md
+++ b/driver/pelican/README.md
@@ -1,0 +1,29 @@
+== Pelican Thermostat Driver ==
+=== Setting up a New Site ===
+Before running the Pelican driver at a new site, you must first configure the
+site's thermostats. This is done with a standalone tool available in the
+`discovery` directory.
+
+The discovery tool first uses the Pelican API to discover the thermostats that
+are installed at the relevant site and then stores information about these
+thermostats in a remote database for fault-tolerance purposes. It requires the
+presence of four files in the current working directory when it is executed:
+  1. `params.yml`: This is identical in structure to the parameter file for the
+     driver itself. The file must contain the following YAML key/value pairs:
+    1. `username`: The username to access the Pelican API
+    2. `password`: The password to access the Pelican API
+    3. `sitename`: The name of the site, as it is referred to by Pelican
+  2. A CA certificate file (e.g. `ca.crt`)
+  3. A certificate file for the remote database (e.g. `my_db.crt`)
+  4. A private key file for authentication with the database (e.g. `my_db.key`)
+
+=== Running the Driver ===
+Once information about the site's thermostats has been stored in the database,
+the Pelican driver is ready to run.
+
+When executed, the driver first reads thermostat information from the database
+before entering the typical Bosswave publish/subscribe loop. Because it
+interacts with the same database as the discovery tool, the driver requires the
+presence of the *same four files* in the current working directory when it is
+executed. Note, however, that the driver expects additional key/value pairs to
+be present in the `params.yml` file.

--- a/driver/pelican/README.md
+++ b/driver/pelican/README.md
@@ -1,5 +1,5 @@
-== Pelican Thermostat Driver ==
-=== Setting up a New Site ===
+## Pelican Thermostat Driver
+### Setting up a New Site
 Before running the Pelican driver at a new site, you must first configure the
 site's thermostats. This is done with a standalone tool available in the
 `discovery` directory.
@@ -17,7 +17,7 @@ presence of four files in the current working directory when it is executed:
   3. A certificate file for the remote database (e.g. `my_db.crt`)
   4. A private key file for authentication with the database (e.g. `my_db.key`)
 
-=== Running the Driver ===
+### Running the Driver
 Once information about the site's thermostats has been stored in the database,
 the Pelican driver is ready to run.
 

--- a/driver/pelican/README.md
+++ b/driver/pelican/README.md
@@ -8,14 +8,14 @@ The discovery tool first uses the Pelican API to discover the thermostats that
 are installed at the relevant site and then stores information about these
 thermostats in a remote database for fault-tolerance purposes. It requires the
 presence of four files in the current working directory when it is executed:
-  1. `params.yml`: This is identical in structure to the parameter file for the
-     driver itself. The file must contain the following YAML key/value pairs:
-    1. `username`: The username to access the Pelican API
-    2. `password`: The password to access the Pelican API
-    3. `sitename`: The name of the site, as it is referred to by Pelican
-  2. A CA certificate file (e.g. `ca.crt`)
-  3. A certificate file for the remote database (e.g. `my_db.crt`)
-  4. A private key file for authentication with the database (e.g. `my_db.key`)
+1. `params.yml`: This is identical in structure to the parameter file for the
+driver itself. The file must contain the following YAML key/value pairs:
+    * `username`: The username to access the Pelican API
+    * `password`: The password to access the Pelican API
+    * `sitename`: The name of the site, as it is referred to by Pelican
+2. A CA certificate file (e.g. `ca.crt`)
+3. A certificate file for the remote database (e.g. `my_db.crt`)
+4. A private key file for authentication with the database (e.g. `my_db.key`)
 
 ### Running the Driver
 Once information about the site's thermostats has been stored in the database,

--- a/driver/pelican/discovery/main.go
+++ b/driver/pelican/discovery/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/SoftwareDefinedBuildings/bw2-contrib/driver/pelican/storage"
+	"github.com/SoftwareDefinedBuildings/bw2-contrib/driver/pelican/types"
+	"github.com/immesys/spawnpoint/spawnable"
+
+	_ "github.com/lib/pq"
+)
+
+func main() {
+	params := spawnable.GetParamsOrExit()
+	username := params.MustString("username")
+	password := params.MustString("password")
+	sitename := params.MustString("sitename")
+
+	pelicans, err := types.DiscoverPelicans(username, password, sitename)
+	if err != nil {
+		fmt.Printf("Failed to discover Pelican thermostats: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Discovered %d Pelican(s), writing to remote DB...\n", len(pelicans))
+	if err = storage.WritePelicans(pelicans, sitename); err != nil {
+		fmt.Printf("Failed to write to database: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Success!")
+}

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/SoftwareDefinedBuildings/bw2-contrib/driver/pelican/storage"
+	"github.com/SoftwareDefinedBuildings/bw2-contrib/driver/pelican/types"
 	"github.com/immesys/spawnpoint/spawnable"
 	bw2 "gopkg.in/immesys/bw2bind.v5"
 )
@@ -26,6 +28,11 @@ type stateMsg struct {
 	Fan             *bool    `msgpack:"fan"`
 }
 
+type stageMsg struct {
+	HeatingStages *int32 `msgpack:"enabled_heating_stages"`
+	CoolingStages *int32 `msgpack:"enabled_cooling_stages"`
+}
+
 func main() {
 	bwClient := bw2.ConnectOrExit("")
 	bwClient.OverrideAutoChainTo(true)
@@ -40,9 +47,9 @@ func main() {
 	password := params.MustString("password")
 	sitename := params.MustString("sitename")
 
-	pelicans, err := DiscoverPelicans(username, password, sitename)
+	pelicans, err := storage.ReadPelicans(username, password, sitename)
 	if err != nil {
-		fmt.Printf("Failed to discover thermostats: %v\n", err)
+		fmt.Printf("Failed to read thermostat info: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -56,7 +63,17 @@ func main() {
 	service := bwClient.RegisterService(baseURI, "s.pelican")
 	tstatIfaces := make([]*bw2.Interface, len(pelicans))
 	for i, pelican := range pelicans {
-		tstatIfaces[i] = service.RegisterInterface(pelican.name, "i.xbos.thermostat")
+		// Ensure thermostat is running with correct number of stages
+		if err := pelican.ModifyStages(&types.PelicanStageParams{
+			HeatingStages: &pelican.HeatingStages,
+			CoolingStages: &pelican.CoolingStages,
+		}); err != nil {
+			fmt.Printf("Failed to configure heating/cooling stages for pelican %s: %s\n",
+				pelican.Name, err)
+			os.Exit(1)
+		}
+
+		tstatIfaces[i] = service.RegisterInterface(pelican.Name, "i.xbos.thermostat")
 
 		tstatIfaces[i].SubscribeSlot("setpoints", func(msg *bw2.SimpleMessage) {
 			po := msg.GetOnePODF(TSTAT_PO_DF)
@@ -71,7 +88,11 @@ func main() {
 				return
 			}
 
-			if err := pelican.ModifySetpoints(&setpoints); err != nil {
+			params := types.PelicanSetpointParams{
+				HeatingSetpoint: setpoints.HeatingSetpoint,
+				CoolingSetpoint: setpoints.CoolingSetpoint,
+			}
+			if err := pelican.ModifySetpoints(&params); err != nil {
 				fmt.Println(err)
 			} else {
 				fmt.Printf("Set heating setpoint to %v and cooling setpoint to %v\n",
@@ -92,7 +113,7 @@ func main() {
 				return
 			}
 
-			params := pelicanStateParams{
+			params := types.PelicanStateParams{
 				HeatingSetpoint: state.HeatingSetpoint,
 				CoolingSetpoint: state.CoolingSetpoint,
 			}
@@ -122,6 +143,35 @@ func main() {
 				fmt.Println(err)
 			} else {
 				fmt.Printf("Set Pelican state to: %+v\n", params)
+			}
+		})
+
+		tstatIfaces[i].SubscribeSlot("stages", func(msg *bw2.SimpleMessage) {
+			po := msg.GetOnePODF(TSTAT_PO_DF)
+			if po == nil {
+				fmt.Println("Received message on state slot without required PO. Dropping.")
+				return
+			}
+
+			var stages stageMsg
+			if err := po.(bw2.MsgPackPayloadObject).ValueInto(&stages); err != nil {
+				fmt.Println("Received malformed PO on stage slot. Dropping.", err)
+				return
+			}
+
+			params := types.PelicanStageParams{
+				HeatingStages: stages.HeatingStages,
+				CoolingStages: stages.CoolingStages,
+			}
+			if err := pelican.ModifyStages(&params); err != nil {
+				fmt.Println(err)
+			} else {
+				if stages.HeatingStages != nil {
+					fmt.Printf("Set pelican heating stages to: %d\n", *stages.HeatingStages)
+				}
+				if stages.CoolingStages != nil {
+					fmt.Printf("Set pelican cooling stages to: %d\n", *stages.CoolingStages)
+				}
 			}
 		})
 	}

--- a/driver/pelican/storage/storage.go
+++ b/driver/pelican/storage/storage.go
@@ -1,0 +1,70 @@
+package storage
+
+import (
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	"github.com/SoftwareDefinedBuildings/bw2-contrib/driver/pelican/types"
+	sqlTypes "github.com/jmoiron/sqlx/types"
+	_ "github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+const dbURL = "postgres://xbosreadonly@corbusier.cs.berkeley.edu:26257/xbos?sslmode=verify-full&sslrootcert=ca.crt&sslcert=client.xbosreadonly.crt&sslkey=client.xbosreadonly.key"
+const dbKey = "pelicans"
+
+func WritePelicans(pelicans []*types.Pelican, sitename string) error {
+	bytes, err := json.Marshal(pelicans)
+	if err != nil {
+		return errors.Wrap(err, "Failed to serialize Pelicans")
+	}
+	var json sqlTypes.JSONText
+	if err := json.Scan(bytes); err != nil {
+		return errors.Wrap(err, "Failed to convert to JSON Text for SQL")
+	}
+
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		return errors.Wrap(err, "Failed to connect to database")
+	}
+	_, err = db.Exec("INSERT INTO SETTINGS (sitename, inserted, key, object) VALUES ($1, $2, $3, $4)",
+		sitename, time.Now(), dbKey, json)
+	if err != nil {
+		return errors.Wrap(err, "Failed to insert into database")
+	}
+
+	return nil
+}
+
+func ReadPelicans(username, password, sitename string) ([]*types.Pelican, error) {
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to connect to database")
+	}
+
+	var ob sqlTypes.JSONText
+	err = db.QueryRow("SELECT object FROM settings where sitename = $1 and key = $2 order by inserted desc limit 1;",
+		sitename, dbKey).Scan(&ob)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to read from database")
+	}
+
+	var pelicans []*types.Pelican
+	if err := ob.Unmarshal(&pelicans); err != nil {
+		return nil, errors.Wrap(err, "Failed to deserialize Pelican info")
+	}
+
+	// To properly regenerate internal fields
+	for i := 0; i < len(pelicans); i++ {
+		pelicans[i] = types.NewPelican(&types.NewPelicanParams{
+			Username:      username,
+			Password:      password,
+			Sitename:      sitename,
+			Name:          pelicans[i].Name,
+			HeatingStages: pelicans[i].HeatingStages,
+			CoolingStages: pelicans[i].CoolingStages,
+		})
+	}
+	return pelicans, nil
+}


### PR DESCRIPTION
This includes the following changes:
  * Allow a Pelican thermostat's number of heating/cooling stages to be manually changed
  * Perform Pelican discovery manually from a dedicated tool
  * Save discovery results (including heating/cooling stages) in a remote database so ground truth can be recovered upon driver failure
  * Reorganize the pelican codebase into multiple packages (not sure if this was the cleanest solution, so looking for input here)
  * Clean up warnings in the Pelican demand-response codebase
  * Fix a Pelican bug where a nil status is returned if thermostat history can't be found