### PR TITLE
Thermostat Occupancy Sensor Integration

### DIFF
--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -256,18 +256,17 @@ func main() {
 					occupancy, err := currentPelican.GetOccupancy()
 					if err != nil {
 						fmt.Printf("Failed to read thermostat occupancy: %s\n", err)
-						done <- true
-					}
-
-					occupancyStatus := occupancyMsg{
-						Occupancy: (occupancy == types.OCCUPANCY_OCCUPIED),
-						Time:      time.Now().UnixNano(),
-					}
-					po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(OCCUPANCY_PO_DF), occupancyStatus)
-					if err != nil {
-						fmt.Printf("Failed to create occupancy msgpack PO: %s\n", err)
 					} else {
-						currentOccupancyIface.PublishSignal("info", po)
+						occupancyStatus := occupancyMsg{
+							Occupancy: (occupancy == types.OCCUPANCY_OCCUPIED),
+							Time:      time.Now().UnixNano(),
+						}
+						po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(OCCUPANCY_PO_DF), occupancyStatus)
+						if err != nil {
+							fmt.Printf("Failed to create occupancy msgpack PO: %s\n", err)
+						} else {
+							currentOccupancyIface.PublishSignal("info", po)
+						}
 					}
 					time.Sleep(pollInt)
 				}

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -266,10 +266,9 @@ func main() {
 					po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(OCCUPANCY_PO_DF), occupancyStatus)
 					if err != nil {
 						fmt.Printf("Failed to create occupancy msgpack PO: %s\n", err)
-						done <- true
+					} else {
+						currentOccupancyIface.PublishSignal("info", po)
 					}
-
-					currentOccupancyIface.PublishSignal("info", po)
 					time.Sleep(pollInt)
 				}
 			}()

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -14,6 +14,7 @@ import (
 
 const TSTAT_PO_DF = "2.1.1.0"
 const DR_PO_DF = "2.1.1.9"
+const OCCUPANCY_PO_DF = "2.1.2.1"
 
 type setpointsMsg struct {
 	HeatingSetpoint *float64 `msgpack:"heating_setpoint"`
@@ -31,6 +32,11 @@ type stateMsg struct {
 type stageMsg struct {
 	HeatingStages *int32 `msgpack:"enabled_heat_stages"`
 	CoolingStages *int32 `msgpack:"enabled_cool_stages"`
+}
+
+type occupancyMsg struct {
+	Occupancy bool  `msgpack:"occupancy"`
+	Time      int64 `msgpack:"time"`
 }
 
 func main() {
@@ -70,6 +76,7 @@ func main() {
 	service := bwClient.RegisterService(baseURI, "s.pelican")
 	tstatIfaces := make([]*bw2.Interface, len(pelicans))
 	drstatIfaces := make([]*bw2.Interface, len(pelicans))
+	occupancyIfaces := make([]*bw2.Interface, len(pelicans))
 	for i, pelican := range pelicans {
 		pelican := pelican
 		name := strings.Replace(pelican.Name, " ", "_", -1)
@@ -78,6 +85,7 @@ func main() {
 		fmt.Println("Transforming", pelican.Name, "=>", name)
 		tstatIfaces[i] = service.RegisterInterface(name, "i.xbos.thermostat")
 		drstatIfaces[i] = service.RegisterInterface(name, "i.xbos.demand_response")
+		occupancyIfaces[i] = service.RegisterInterface(name, "i.xbos.occupancy")
 
 		// Ensure thermostat is running with correct number of stages
 		if err := pelican.ModifyStages(&types.PelicanStageParams{
@@ -199,6 +207,8 @@ func main() {
 		currentPelican := pelican
 		currentIface := tstatIfaces[i]
 		currentDRIface := drstatIfaces[i]
+		currentOccupancyIface := occupancyIfaces[i]
+
 		go func() {
 			for {
 				if status, err := currentPelican.GetStatus(); err != nil {
@@ -233,6 +243,37 @@ func main() {
 				time.Sleep(pollDr)
 			}
 		}()
+
+		occupancy, err := currentPelican.GetOccupancy()
+		if err != nil {
+			fmt.Printf("Failed to retrieve initial occupancy reading: %s\n", err)
+			return
+		}
+		// Start occupancy tracking loop only if thermostat has the necessary sensor
+		if occupancy != types.OCCUPANCY_UNKNOWN {
+			go func() {
+				for {
+					occupancy, err := currentPelican.GetOccupancy()
+					if err != nil {
+						fmt.Printf("Failed to read thermostat occupancy: %s\n", err)
+						done <- true
+					}
+
+					occupancyStatus := occupancyMsg{
+						Occupancy: (occupancy == types.OCCUPANCY_OCCUPIED),
+						Time:      time.Now().UnixNano(),
+					}
+					po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(OCCUPANCY_PO_DF), occupancyStatus)
+					if err != nil {
+						fmt.Printf("Failed to create occupancy msgpack PO: %s\n", err)
+						done <- true
+					}
+
+					currentOccupancyIface.PublishSignal("info", po)
+					time.Sleep(pollInt)
+				}
+			}()
+		}
 	}
 	<-done
 }

--- a/driver/pelican/types/demandResponse.go
+++ b/driver/pelican/types/demandResponse.go
@@ -47,7 +47,7 @@ type ADREvent struct {
 }
 
 func (pel *Pelican) TrackDREvent() (*ADREvent, error) {
-	resp, _, errs := pel.req.Get(pel.target).
+	resp, _, errs := pel.drReq.Get(pel.target).
 		Param("username", pel.username).
 		Param("password", pel.password).
 		Param("request", "get").

--- a/driver/pelican/types/occupancy.go
+++ b/driver/pelican/types/occupancy.go
@@ -1,0 +1,67 @@
+package types
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+)
+
+const (
+	OCCUPANCY_UNKNOWN = iota
+	OCCUPANCY_OCCUPIED
+	OCCUPANCY_UNOCCUPIED
+)
+
+type occupancyResponse struct {
+	Success    int        `xml:"success"`
+	Thermostat thermostat `xml:"Thermostat"`
+	Message    string     `xml:"message"`
+}
+
+type thermostat struct {
+	Sensors []childSensor `xml:"slaves"`
+}
+
+type childSensor struct {
+	Name  string `xml:"name"`
+	Type  string `xml:"type"`
+	Value string `xml:"value"`
+}
+
+func (pel *Pelican) GetOccupancy() (int, error) {
+	resp, _, errs := pel.occupanyReq.Get(pel.target).
+		Param("username", pel.username).
+		Param("password", pel.password).
+		Param("request", "get").
+		Param("object", "thermostat").
+		Param("selection", fmt.Sprintf("name:%s;", pel.Name)).
+		Param("value", "slaves;").
+		End()
+
+	if errs != nil {
+		return 0, fmt.Errorf("Error retrieving thermostat occupancy data: %s", errs)
+	}
+	defer resp.Body.Close()
+
+	var occResp occupancyResponse
+	dec := xml.NewDecoder(resp.Body)
+	if err := dec.Decode(&occResp); err != nil {
+		return 0, fmt.Errorf("Failed to decode occupancy API result: %s", err)
+	}
+	if occResp.Success == 0 {
+		return 0, fmt.Errorf("Error retrieving thermostat occupancy data: %s", occResp.Message)
+	}
+
+	status := OCCUPANCY_UNKNOWN
+	for _, sensor := range occResp.Thermostat.Sensors {
+		if strings.ToLower(sensor.Type) == "occupancy sensor" {
+			if strings.ToLower(sensor.Value) == "occupied" {
+				status = OCCUPANCY_OCCUPIED
+			} else {
+				status = OCCUPANCY_UNOCCUPIED
+			}
+			break
+		}
+	}
+	return status, nil
+}

--- a/driver/pelican/types/pelican.go
+++ b/driver/pelican/types/pelican.go
@@ -37,6 +37,8 @@ type Pelican struct {
 	target        string
 	timezone      *time.Location
 	req           *gorequest.SuperAgent
+	drReq         *gorequest.SuperAgent
+	occupanyReq   *gorequest.SuperAgent
 }
 
 type PelicanStatus struct {
@@ -158,6 +160,8 @@ func NewPelican(params *NewPelicanParams) (*Pelican, error) {
 		TimezoneName:  params.Timezone,
 		timezone:      timezone,
 		req:           gorequest.New(),
+		drReq:         gorequest.New(),
+		occupanyReq:   gorequest.New(),
 	}, nil
 }
 


### PR DESCRIPTION
These changes allow us to collect occupancy data from occupancy sensors that are associated with Pelican thermostats and report data through the Pelican API.

This has been tested on thermostats bound to Enlighted occupancy sensors.