### PR TITLE
Thermostat Schedule Retrieval Code

### DIFF
--- a/driver/pelican/interface.md
+++ b/driver/pelican/interface.md
@@ -34,7 +34,7 @@ Each Pelican Thermostat has three potential schedule settings.
 
 Next, it's wise if we attempt to define what a "daily schedule" actually looks like. Each day's schedule consists of a series of what we'll call "blocks". Each block details a certain number of settings that are enacted at a certain time of day. This is encapsulated by the ThermostatBlockSchedule struct. For example, one might have a series of four different blocks with time intervals at 6:00 a.m., 11:00 a.m., 4:00 p.m., and 6:00 p.m. At each of these times, the associated cool temperature, heat temperature, and system settings are all enacted.
 
-The outermost struct, "ThermostatSchedule", maps each day of the week (Sunday - Saturday) to their respective daily schedules which is represented as an array of ThermostatBlockSchedule objects. Each day may have a different series of configurations that are enforced at different times, which is why there are multiple blocks per day. This is the struct that is delivered to the user for getting and setting purposes.
+The outermost struct, "ThermostatSchedule", maps each day of the week (Sunday - Saturday) to their respective daily schedules which is represented as an array of ThermostatBlockSchedule objects. Each day may have a different series of configurations that are enforced at different times, which is why there are multiple blocks per day. Ultimately, the pelican's "GetSchedule" function returns a pointer to this struct, which encapsulates the entire weekly schedule for that particular pelican thermostat.
 
 ##### Thermostat Block Schedule Struct Fields Explanation
 

--- a/driver/pelican/interface.md
+++ b/driver/pelican/interface.md
@@ -1,0 +1,40 @@
+### Pelican Schedule Interface Outline
+
+##### Context
+
+The following structs define the way users interact with the Scheduling interface of the Pelican thermostats. These structs are used to define the weekly schedule and will be interpretted by the thermSchedule.go code to retrieve/view in addition to making changes to the existing schedule for individual thermostats within a particular site. These structs are public and accessible to anyone who subscribes to the allotted endpoint or publishes to the assigned signal.
+
+##### Schedule Structs
+
+// Struct mapping each day of the week to its daily schedule <br>
+type ThermostatSchedule struct {<br>
+&nbsp;&nbsp;&nbsp;DaySchedules map[string]ThermostatDaySchedule `msgpack:"day_schedules"`<br>
+}<br>
+
+// Struct containing a series of blocks that describes a one day schedule <br>
+type ThermostatDaySchedule struct { <br>
+&nbsp;&nbsp;&nbsp;Blocks []ThermostatBlockSchedule `msgpack:blocks` <br>
+} <br>
+
+// Struct containing data defining the settings of each schedule block <br>
+type ThermostatBlockSchedule struct { <br>
+&nbsp;&nbsp;&nbsp;CoolSetting float64 `msgpack:"cool_setting"` <br>
+&nbsp;&nbsp;&nbsp;HeatSetting float64 `msgpack:"heat_setting"` <br>
+&nbsp;&nbsp;&nbsp;System      string  `msgpack:"system"` <br>
+&nbsp;&nbsp;&nbsp;Time        string  `msgpack:"time"` <br>
+}
+
+##### Schedule Structs Explanation
+
+Each Pelican Thermostat has three potential schedule settings.
+1. Weekly: Each day of the week (Sun - Sat) has a unique daily schedule setting
+2. Daily: Each day of the week has the same daily schedule
+3. Weekday/Weekend: Per the name, weekdays and weekends have different schedules.
+
+Next, it's wise if we attempt to define what a "daily schedule" actually looks like. Each day's schedule consist of a series of what we'll call "blocks". Each block details a certain number of settings that are enacted at a certain time of day. This is encapsulated by the ThermostatBlockSchedule struct. For example, one might have a series of four different blocks with time intervals at 6:00 a.m., 11:00 a.m., 4:00 p.m., and 6:00 p.m. At each of these times, the associated cool temperature, heat temperature, and system settings are all enacted.
+
+Going one layer above, the ThermostatDaySchedule struct represents an array of blocks. The purpose of this struct is to represent the schedule of one day a.k.a a series of blocks. Last but not least, the outermost struct, "ThermostatSchedule", maps each day of the week (Sunday - Saturday) to their respective daily schedules (ThermostatDaySchedule struct). This is the struct that is delivered to the user for getting and setting purposes.
+
+##### XBOS Interface Configuration
+
+The current version of XBOS uses YAML files to define the expectations for the output of different functionalities of the driver code from the bw2-contrib repository. There are a couple limitations regarding what the YAML files are able to represent. The incumbent version of XBOS features protobuf definitions for messages. When the next release of XBOS comes, both new and existing YAML files will be created and modified to reflect the outputs' types more accurately.

--- a/driver/pelican/interface.md
+++ b/driver/pelican/interface.md
@@ -14,15 +14,19 @@ type ThermostatSchedule struct {
 
 // Struct containing a series of blocks that describes a one day schedule
 type ThermostatDaySchedule struct {
-  Blocks []ThermostatBlockSchedule `msgpack:blocks`
+  Blocks []ThermostatBlockSchedule `msgpack:"blocks"`
 }
 
 // Struct containing data defining the settings of each schedule block
 type ThermostatBlockSchedule struct {
-  CoolSetting float64 `msgpack:"cool_setting"` // Cooling turns on when room temperature exceeds cool setting temp.
-  HeatSetting float64 `msgpack:"heat_setting"` // Heating turns on when room temperature drops below heat setting temp.
-  System      string  `msgpack:"system"`       // Indicates if system is heating, cooling, off, or set to auto
-  Time        string  `msgpack:"time"`         // Indicates the time of day which the above settings are enacted.
+  // Cooling turns on when room temperature exceeds cool setting temp.
+  CoolSetting float64 `msgpack:"cool_setting"`
+  // Heating turns on when room temperature drops below heat setting temp.
+  HeatSetting float64 `msgpack:"heat_setting"`
+  // Indicates if system is heating, cooling, off, or set to auto
+  System      string  `msgpack:"system"`
+  // Indicates the time of day which the above settings are enacted.
+  Time        string  `msgpack:"time"`
 }
 ```
 
@@ -60,6 +64,14 @@ Three fields are configured.
 - Frequency indicates the interval with which this event occurs.
 - Wkst tells us which day of the week (Sunday - Saturday) this event occurs.
 - Dtstart is a required field that indicates the "start date" of the particular event. In Go, the Dtstart field is a time.Date object, which is initialized with the following parameters: year, month, day, hour minute, second, millisecond, timezone. For our purposes, there is no real concept of a "start date", just the time, so the year, month, and day parameters are filled with dummy values of 0. Only hour, minute, and timezone (which can be determined from the Pelican settings + schedule) are filled in. As long as an individual knows the time is in RRule format, he or she will be able to determine each field.
+
+The translation from the above RRule format to a string is performed using the RRule-go module, specifically this function linked here:
+https://github.com/teambition/rrule-go/blob/master/str.go#L123
+
+Within the thermSchedule.go code, the last line of the convertTimeToRRule function calls the ".string()" function of the RRule object. The implementation of this function is fairly straightforward. In a nutshell, the conversion function scans through each of the RRule object's fields. The "key-value" pair of each field is appended to a string object, which is ultimately returned. Some helper functions are used primarily for casting a variety of types into a string, such as appendIntsOption, timeToStr (for Dtstart), and append. In a general sense, the conversion function is meant to achieve two things:
+
+1. Be as human readable as possible. If one reads the resulting string output, he or she should easily be able to identify the interval, frequency, count, and start/end dates of the respective event.
+2. Can be converted back into RRule format. The RRule-go module has a complementary ".StrToRRule(rfcString string)" function that converts from string back to an RRule object.
 
 ##### XBOS Interface Configuration
 

--- a/driver/pelican/interface.md
+++ b/driver/pelican/interface.md
@@ -73,6 +73,26 @@ Within the thermSchedule.go code, the last line of the convertTimeToRRule functi
 1. Be as human readable as possible. If one reads the resulting string output, he or she should easily be able to identify the interval, frequency, count, and start/end dates of the respective event.
 2. Can be converted back into RRule format. The RRule-go module has a complementary ".StrToRRule(rfcString string)" function that converts from string back to an RRule object.
 
+##### Time Format Conversion Examples
+
+The following is an example of what we can expect the conversion to take in and output for different types of events with different settings
+
+With the Pelican Thermostats, we will typically have the following settings:
+
+```
+Frequency: Weekly
+Wkst: Day of Week (Sunday, Monday...Saturday)
+Dtstart: time.Date(0, 0, 0,  Hour, Minute, 0, 0, Timezone)
+```
+
+As a reminder, the parameters of the time.Date object are Year, Month, Date, Hour, Minute, Second, Millisecond, and Timezone. Frequency is always set to "Weekly". Wkst and the Hour/Minute/Timezone depend on the value that is being retrieved in addition to the Pelican's timezone. The NewRRule object's fields are populated with these values and the aforementioned ".String()" method is called. Assuming the Wkst is Sunday and Dtstart is 6:00 a.m. with a U.S. Pacific Timezone, the output will look like this:
+
+```
+FREQ=WEEKLY;DTSTART=-00011201T055258Z;WKST=SU
+```
+
+Another example can be found from the RRule-go Github page at this link: https://github.com/teambition/rrule-go/blob/master/example/main.go. This contains a pretty comprehensive set of RRule's with different assortments of fields in them. In general, if a new field is added to the RRule, you can expect to see a concise, human readable string added to the output string.
+
 ##### XBOS Interface Configuration
 
 The current version of XBOS uses YAML files to define the expectations for the output of different functionalities of the driver code from the bw2-contrib repository. There are a couple limitations regarding what the YAML files are able to represent. The incumbent version of XBOS features protobuf definitions for messages. When the next release of XBOS comes, both new and existing YAML files will be created and modified to reflect the outputs' types more accurately.

--- a/driver/pelican/interface.md
+++ b/driver/pelican/interface.md
@@ -84,7 +84,7 @@ Wkst: Day of Week (Sunday, Monday...Saturday)
 Dtstart: time.Date(0, 0, 0,  Hour, Minute, 0, 0, Timezone)
 ```
 
-As a reminder, the parameters of the time.Date object are Year, Month, Date, Hour, Minute, Second, Millisecond, and Timezone. Frequency is always set to "Weekly". Wkst and the Hour/Minute/Timezone depend on the value that is being retrieved in addition to the Pelican's timezone. The NewRRule object's fields are populated with these values and the aforementioned ".String()" method is called. Assuming the Wkst is Sunday and Dtstart is 6:00 a.m. with a U.S. Pacific Timezone, the output will look like this:
+As a reminder, the parameters of the time.Date object are Year, Month, Date, Hour, Minute, Second, Millisecond, and Timezone. Frequency is always set to "Weekly". Wkst and the Hour/Minute/Timezone depend on the value that is being retrieved in addition to the Pelican's timezone. The NewRRule object's fields are populated with these values and the aforementioned ".String()" method is called. Assuming the Wkst is Sunday and Dtstart is 6:00 a.m. in U.S. Pacific Standard Time, the output will look like this:
 
 ```
 FREQ=WEEKLY;DTSTART=-00011201T055258Z;WKST=SU

--- a/driver/pelican/interface.md
+++ b/driver/pelican/interface.md
@@ -9,12 +9,7 @@ The following structs define the way users interact with the Scheduling interfac
 ```
 // Struct mapping each day of the week to its daily schedule
 type ThermostatSchedule struct {
-  DaySchedules map[string]ThermostatDaySchedule `msgpack:"day_schedules"`
-}
-
-// Struct containing a series of blocks that describes a one day schedule
-type ThermostatDaySchedule struct {
-  Blocks []ThermostatBlockSchedule `msgpack:"blocks"`
+  DaySchedules map[string]([]ThermostatBlockSchedule) `msgpack:"day_schedules"`
 }
 
 // Struct containing data defining the settings of each schedule block
@@ -39,7 +34,7 @@ Each Pelican Thermostat has three potential schedule settings.
 
 Next, it's wise if we attempt to define what a "daily schedule" actually looks like. Each day's schedule consists of a series of what we'll call "blocks". Each block details a certain number of settings that are enacted at a certain time of day. This is encapsulated by the ThermostatBlockSchedule struct. For example, one might have a series of four different blocks with time intervals at 6:00 a.m., 11:00 a.m., 4:00 p.m., and 6:00 p.m. At each of these times, the associated cool temperature, heat temperature, and system settings are all enacted.
 
-Going one layer above, the ThermostatDaySchedule struct represents an array of blocks. The purpose of this struct is to represent the schedule of one day a.k.a a series of blocks. Last but not least, the outermost struct, "ThermostatSchedule", maps each day of the week (Sunday - Saturday) to their respective daily schedules (ThermostatDaySchedule struct). This is the struct that is delivered to the user for getting and setting purposes.
+The outermost struct, "ThermostatSchedule", maps each day of the week (Sunday - Saturday) to their respective daily schedules which is represented as an array of ThermostatBlockSchedule objects. Each day may have a different series of configurations that are enforced at different times, which is why there are multiple blocks per day. This is the struct that is delivered to the user for getting and setting purposes.
 
 ##### Thermostat Block Schedule Struct Fields Explanation
 

--- a/driver/pelican/interface.md
+++ b/driver/pelican/interface.md
@@ -2,7 +2,7 @@
 
 ##### Context
 
-The following structs define the way users interact with the Scheduling interface of the Pelican thermostats. These structs are used to define the weekly schedule and will be interpretted by the thermSchedule.go code to retrieve/view in addition to making changes to the existing schedule for individual thermostats within a particular site. These structs are public and accessible to anyone who subscribes to the allotted endpoint or publishes to the assigned signal.
+The following structs define the way users interact with the Scheduling interface of the Pelican thermostats. These structs are used to define the weekly schedule and will be interpreted by the thermSchedule.go code to retrieve/view in addition to making changes to the existing schedule for individual thermostats within a particular site. These structs are public and accessible to anyone who subscribes to the allotted endpoint or publishes to the assigned signal.
 
 ##### Schedule Structs
 
@@ -37,7 +37,7 @@ Each Pelican Thermostat has three potential schedule settings.
 2. Daily: Each day of the week has the same daily schedule
 3. Weekday/Weekend: Per the name, weekdays and weekends have different schedules.
 
-Next, it's wise if we attempt to define what a "daily schedule" actually looks like. Each day's schedule consist of a series of what we'll call "blocks". Each block details a certain number of settings that are enacted at a certain time of day. This is encapsulated by the ThermostatBlockSchedule struct. For example, one might have a series of four different blocks with time intervals at 6:00 a.m., 11:00 a.m., 4:00 p.m., and 6:00 p.m. At each of these times, the associated cool temperature, heat temperature, and system settings are all enacted.
+Next, it's wise if we attempt to define what a "daily schedule" actually looks like. Each day's schedule consists of a series of what we'll call "blocks". Each block details a certain number of settings that are enacted at a certain time of day. This is encapsulated by the ThermostatBlockSchedule struct. For example, one might have a series of four different blocks with time intervals at 6:00 a.m., 11:00 a.m., 4:00 p.m., and 6:00 p.m. At each of these times, the associated cool temperature, heat temperature, and system settings are all enacted.
 
 Going one layer above, the ThermostatDaySchedule struct represents an array of blocks. The purpose of this struct is to represent the schedule of one day a.k.a a series of blocks. Last but not least, the outermost struct, "ThermostatSchedule", maps each day of the week (Sunday - Saturday) to their respective daily schedules (ThermostatDaySchedule struct). This is the struct that is delivered to the user for getting and setting purposes.
 
@@ -46,7 +46,7 @@ Going one layer above, the ThermostatDaySchedule struct represents an array of b
 - CoolSetting: The cool setting refers to the temperature at which the system begins cooling. In other words, if the room temperature surpasses this threshold, the cooling system is activated. The unit of temperature is Fahrenheit.
 - HeatSetting: The heat setting refers to the temperature at which the system begins heating. In other words, if the room temperature falls below this threshold, the heating system is activated. The unit of temperature is Fahrenheit.
 - System: This indicates what the system is currently doing. There are four possible settings (heat/cool/off/auto) which are pretty self explanatory. Heat and cool mean the systems heating or cooling the room. Auto means that the system will automatically heat or cool according to the room temperature and cool/heat thresholds.
-- Time: Time describes what time of day the particular block's settings are enacted (i.e. 6:00:AM). This time is in the RRule format (https://tools.ietf.org/html/rfc5545), and the rrule-go library is used to convert the given time into the designated format. The following section describes how time is formatted and defined in greater detail.
+- Time: Time describes what time of day the particular block's settings are enacted (e.g. 6:00:AM). This time is in the [RRule format](https://tools.ietf.org/html/rfc5545), and the rrule-go library is used to convert the given time into the designated format. The following section describes how time is formatted and defined in greater detail.
 
 ##### A Deeper Dive into Time Format (RRule)
 
@@ -65,8 +65,7 @@ Three fields are configured.
 - Wkst tells us which day of the week (Sunday - Saturday) this event occurs.
 - Dtstart is a required field that indicates the "start date" of the particular event. In Go, the Dtstart field is a time.Date object, which is initialized with the following parameters: year, month, day, hour minute, second, millisecond, timezone. For our purposes, there is no real concept of a "start date", just the time, so the year, month, and day parameters are filled with dummy values of 0. Only hour, minute, and timezone (which can be determined from the Pelican settings + schedule) are filled in. As long as an individual knows the time is in RRule format, he or she will be able to determine each field.
 
-The translation from the above RRule format to a string is performed using the RRule-go module, specifically this function linked here:
-https://github.com/teambition/rrule-go/blob/master/str.go#L123
+The translation from the above RRule format to a string is performed using the RRule-go module, specifically this function linked [here](https://github.com/teambition/rrule-go/blob/master/str.go#L123).
 
 Within the thermSchedule.go code, the last line of the convertTimeToRRule function calls the ".string()" function of the RRule object. The implementation of this function is fairly straightforward. In a nutshell, the conversion function scans through each of the RRule object's fields. The "key-value" pair of each field is appended to a string object, which is ultimately returned. Some helper functions are used primarily for casting a variety of types into a string, such as appendIntsOption, timeToStr (for Dtstart), and append. In a general sense, the conversion function is meant to achieve two things:
 
@@ -91,7 +90,7 @@ As a reminder, the parameters of the time.Date object are Year, Month, Date, Hou
 FREQ=WEEKLY;DTSTART=-00011201T055258Z;WKST=SU
 ```
 
-Another example can be found from the RRule-go Github page at this link: https://github.com/teambition/rrule-go/blob/master/example/main.go. This contains a pretty comprehensive set of RRule's with different assortments of fields in them. In general, if a new field is added to the RRule, you can expect to see a concise, human readable string added to the output string.
+Another example can be found from the RRule-go Github [example page](https://github.com/teambition/rrule-go/blob/master/example/main.go). This contains a pretty comprehensive set of RRule's with different assortments of fields in them. In general, if a new field is added to the RRule, you can expect to see a concise, human readable string added to the output string.
 
 ##### XBOS Interface Configuration
 

--- a/driver/pelican/interface.md
+++ b/driver/pelican/interface.md
@@ -6,23 +6,25 @@ The following structs define the way users interact with the Scheduling interfac
 
 ##### Schedule Structs
 
-// Struct mapping each day of the week to its daily schedule <br>
-type ThermostatSchedule struct {<br>
-&nbsp;&nbsp;&nbsp;DaySchedules map[string]ThermostatDaySchedule `msgpack:"day_schedules"`<br>
-}<br>
-
-// Struct containing a series of blocks that describes a one day schedule <br>
-type ThermostatDaySchedule struct { <br>
-&nbsp;&nbsp;&nbsp;Blocks []ThermostatBlockSchedule `msgpack:blocks` <br>
-} <br>
-
-// Struct containing data defining the settings of each schedule block <br>
-type ThermostatBlockSchedule struct { <br>
-&nbsp;&nbsp;&nbsp;CoolSetting float64 `msgpack:"cool_setting"` <br>
-&nbsp;&nbsp;&nbsp;HeatSetting float64 `msgpack:"heat_setting"` <br>
-&nbsp;&nbsp;&nbsp;System      string  `msgpack:"system"` <br>
-&nbsp;&nbsp;&nbsp;Time        string  `msgpack:"time"` <br>
+```
+// Struct mapping each day of the week to its daily schedule
+type ThermostatSchedule struct {
+  DaySchedules map[string]ThermostatDaySchedule `msgpack:"day_schedules"`
 }
+
+// Struct containing a series of blocks that describes a one day schedule
+type ThermostatDaySchedule struct {
+  Blocks []ThermostatBlockSchedule `msgpack:blocks`
+}
+
+// Struct containing data defining the settings of each schedule block
+type ThermostatBlockSchedule struct {
+  CoolSetting float64 `msgpack:"cool_setting"` // Cooling turns on when room temperature exceeds cool setting temp.
+  HeatSetting float64 `msgpack:"heat_setting"` // Heating turns on when room temperature drops below heat setting temp.
+  System      string  `msgpack:"system"`       // Indicates if system is heating, cooling, off, or set to auto
+  Time        string  `msgpack:"time"`         // Indicates the time of day which the above settings are enacted.
+}
+```
 
 ##### Schedule Structs Explanation
 
@@ -34,6 +36,30 @@ Each Pelican Thermostat has three potential schedule settings.
 Next, it's wise if we attempt to define what a "daily schedule" actually looks like. Each day's schedule consist of a series of what we'll call "blocks". Each block details a certain number of settings that are enacted at a certain time of day. This is encapsulated by the ThermostatBlockSchedule struct. For example, one might have a series of four different blocks with time intervals at 6:00 a.m., 11:00 a.m., 4:00 p.m., and 6:00 p.m. At each of these times, the associated cool temperature, heat temperature, and system settings are all enacted.
 
 Going one layer above, the ThermostatDaySchedule struct represents an array of blocks. The purpose of this struct is to represent the schedule of one day a.k.a a series of blocks. Last but not least, the outermost struct, "ThermostatSchedule", maps each day of the week (Sunday - Saturday) to their respective daily schedules (ThermostatDaySchedule struct). This is the struct that is delivered to the user for getting and setting purposes.
+
+##### Thermostat Block Schedule Struct Fields Explanation
+
+- CoolSetting: The cool setting refers to the temperature at which the system begins cooling. In other words, if the room temperature surpasses this threshold, the cooling system is activated. The unit of temperature is Fahrenheit.
+- HeatSetting: The heat setting refers to the temperature at which the system begins heating. In other words, if the room temperature falls below this threshold, the heating system is activated. The unit of temperature is Fahrenheit.
+- System: This indicates what the system is currently doing. There are four possible settings (heat/cool/off/auto) which are pretty self explanatory. Heat and cool mean the systems heating or cooling the room. Auto means that the system will automatically heat or cool according to the room temperature and cool/heat thresholds.
+- Time: Time describes what time of day the particular block's settings are enacted (i.e. 6:00:AM). This time is in the RRule format (https://tools.ietf.org/html/rfc5545), and the rrule-go library is used to convert the given time into the designated format. The following section describes how time is formatted and defined in greater detail.
+
+##### A Deeper Dive into Time Format (RRule)
+
+Within "thermoSchedule.go", this particular block in the "convertTimeToRRule" function is responsible for creating the RRule format.
+
+```
+rruleSched, _ := rrule.NewRRule(rrule.ROption{
+  Freq:    rrule.WEEKLY,
+  Wkst:    weekRRule[dayOfWeek],
+  Dtstart: time.Date(0, 0, 0, hour, minute, 0, 0, timezone),
+})
+```
+
+Three fields are configured.
+- Frequency indicates the interval with which this event occurs.
+- Wkst tells us which day of the week (Sunday - Saturday) this event occurs.
+- Dtstart is a required field that indicates the "start date" of the particular event. In Go, the Dtstart field is a time.Date object, which is initialized with the following parameters: year, month, day, hour minute, second, millisecond, timezone. For our purposes, there is no real concept of a "start date", just the time, so the year, month, and day parameters are filled with dummy values of 0. Only hour, minute, and timezone (which can be determined from the Pelican settings + schedule) are filled in. As long as an individual knows the time is in RRule format, he or she will be able to determine each field.
 
 ##### XBOS Interface Configuration
 

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -94,7 +94,7 @@ func main() {
 		fmt.Println("Transforming", pelican.Name, "=>", name)
 		tstatIfaces[i] = service.RegisterInterface(name, "i.xbos.thermostat")
 		drstatIfaces[i] = service.RegisterInterface(name, "i.xbos.demand_response")
-		schedstatIfaces[i] = service.RegisterInterface(name, "i.xbos.schedule")
+		schedstatIfaces[i] = service.RegisterInterface(name, "i.xbos.thermostat_schedule")
 		occupancyIfaces[i] = service.RegisterInterface(name, "i.xbos.occupancy")
 
 		// Ensure thermostat is running with correct number of stages

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -257,7 +257,7 @@ func main() {
 
 		go func() {
 			for {
-				if schedStatus, schedErr := currentPelican.GetSchedule(sitename); schedErr != nil {
+				if schedStatus, schedErr := currentPelican.GetSchedule(); schedErr != nil {
 					fmt.Printf("Failed to retrieve Pelican's Schedule: %v\n", schedErr)
 				} else {
 					fmt.Printf("%s Schedule: %+v\n", currentPelican.Name, schedStatus)

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -15,6 +15,7 @@ import (
 const TSTAT_PO_DF = "2.1.1.0"
 const DR_PO_DF = "2.1.1.9"
 const OCCUPANCY_PO_DF = "2.1.2.1"
+const SCHED_PO_DF = "2.1.2.2"
 
 type setpointsMsg struct {
 	HeatingSetpoint *float64 `msgpack:"heating_setpoint"`
@@ -73,9 +74,17 @@ func main() {
 		os.Exit(1)
 	}
 
+	pollSchedStr := params.MustString("poll_interval_sched")
+	pollSched, schedErr := time.ParseDuration(pollSchedStr)
+	if schedErr != nil {
+		fmt.Printf("Invalid schedule poll interval specified: %v\n", schedErr)
+		os.Exit(1)
+	}
+
 	service := bwClient.RegisterService(baseURI, "s.pelican")
 	tstatIfaces := make([]*bw2.Interface, len(pelicans))
 	drstatIfaces := make([]*bw2.Interface, len(pelicans))
+	schedstatIfaces := make([]*bw2.Interface, len(pelicans))
 	occupancyIfaces := make([]*bw2.Interface, len(pelicans))
 	for i, pelican := range pelicans {
 		pelican := pelican
@@ -85,6 +94,7 @@ func main() {
 		fmt.Println("Transforming", pelican.Name, "=>", name)
 		tstatIfaces[i] = service.RegisterInterface(name, "i.xbos.thermostat")
 		drstatIfaces[i] = service.RegisterInterface(name, "i.xbos.demand_response")
+		schedstatIfaces[i] = service.RegisterInterface(name, "i.xbos.schedule")
 		occupancyIfaces[i] = service.RegisterInterface(name, "i.xbos.occupancy")
 
 		// Ensure thermostat is running with correct number of stages
@@ -207,6 +217,7 @@ func main() {
 		currentPelican := pelican
 		currentIface := tstatIfaces[i]
 		currentDRIface := drstatIfaces[i]
+		currentSchedIface := schedstatIfaces[i]
 		currentOccupancyIface := occupancyIfaces[i]
 
 		go func() {
@@ -241,6 +252,22 @@ func main() {
 					currentDRIface.PublishSignal("info", po)
 				}
 				time.Sleep(pollDr)
+			}
+		}()
+
+		go func() {
+			for {
+				if schedStatus, schedErr := currentPelican.GetSchedule(sitename); schedErr != nil {
+					fmt.Printf("Failed to retrieve Pelican's Schedule: %v\n", schedErr)
+				} else if schedStatus != nil {
+					fmt.Printf("%s Schedule: %+v\n", currentPelican.Name, schedStatus)
+					po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(SCHED_PO_DF), schedStatus)
+					if err != nil {
+						fmt.Printf("Failed to create Schedule msgpack PO: %v", err)
+					}
+					currentSchedIface.PublishSignal("info", po)
+				}
+				time.Sleep(pollSched)
 			}
 		}()
 

--- a/driver/pelican/main.go
+++ b/driver/pelican/main.go
@@ -259,7 +259,7 @@ func main() {
 			for {
 				if schedStatus, schedErr := currentPelican.GetSchedule(sitename); schedErr != nil {
 					fmt.Printf("Failed to retrieve Pelican's Schedule: %v\n", schedErr)
-				} else if schedStatus != nil {
+				} else {
 					fmt.Printf("%s Schedule: %+v\n", currentPelican.Name, schedStatus)
 					po, err := bw2.CreateMsgPackPayloadObject(bw2.FromDotForm(SCHED_PO_DF), schedStatus)
 					if err != nil {

--- a/driver/pelican/params.yml
+++ b/driver/pelican/params.yml
@@ -5,3 +5,4 @@ sitename: <pelican site name>
 name: <thermostat name>
 poll_interval: <status poll interval>
 poll_interval_dr: <dr status poll interval>
+poll_interval_sched: <schedule poll interval>

--- a/driver/pelican/types/occupancy.go
+++ b/driver/pelican/types/occupancy.go
@@ -29,7 +29,7 @@ type childSensor struct {
 }
 
 func (pel *Pelican) GetOccupancy() (int, error) {
-	resp, _, errs := pel.occupanyReq.Get(pel.target).
+	resp, _, errs := pel.occupancyReq.Get(pel.target).
 		Param("username", pel.username).
 		Param("password", pel.password).
 		Param("request", "get").

--- a/driver/pelican/types/pelican.go
+++ b/driver/pelican/types/pelican.go
@@ -38,6 +38,7 @@ type Pelican struct {
 	CoolingStages int32
 	TimezoneName  string
 	target        string
+	cookieTime    time.Time
 	timezone      *time.Location
 	cookie        *http.Cookie
 	req           *gorequest.SuperAgent

--- a/driver/pelican/types/pelican.go
+++ b/driver/pelican/types/pelican.go
@@ -38,7 +38,8 @@ type Pelican struct {
 	timezone      *time.Location
 	req           *gorequest.SuperAgent
 	drReq         *gorequest.SuperAgent
-	occupanyReq   *gorequest.SuperAgent
+	occupancyReq  *gorequest.SuperAgent
+	scheduleReq   *gorequest.SuperAgent
 }
 
 type PelicanStatus struct {
@@ -161,7 +162,8 @@ func NewPelican(params *NewPelicanParams) (*Pelican, error) {
 		timezone:      timezone,
 		req:           gorequest.New(),
 		drReq:         gorequest.New(),
-		occupanyReq:   gorequest.New(),
+		occupancyReq:  gorequest.New(),
+		scheduleReq:   gorequest.New(),
 	}, nil
 }
 

--- a/driver/pelican/types/thermSchedule.go
+++ b/driver/pelican/types/thermSchedule.go
@@ -194,7 +194,6 @@ func (pel *Pelican) getScheduleByDay(dayOfWeek int, epnum float64, thermostatID 
 		} else {
 			returnBlock.Time = rruleTime
 		}
-
 		daySchedule = append(daySchedule, returnBlock)
 	}
 	return &daySchedule, nil
@@ -220,6 +219,7 @@ func convertTimeToRRule(dayOfWeek int, blockTime string, timezone *time.Location
 
 // Handles setting the Pelican fields (cookie, id) that can only be retrieved by AJAX Requests
 func (pel *Pelican) setCookieAndID() error {
+	// Set the cookie field using the pelican's login information
 	loginInfo := map[string]interface{}{
 		"username": pel.username,
 		"password": pel.password,
@@ -231,11 +231,11 @@ func (pel *Pelican) setCookieAndID() error {
 	}
 	pel.cookie = (*http.Response)(respLogin).Cookies()[0]
 
+	// Set the Thermostat ID using the thermostat resources AJAX Request
 	respTherms, _, errsTherms := gorequest.New().Get(fmt.Sprintf("https://%s.officeclimatecontrol.net/ajaxSchedule.cgi?request=getResourcesExtended&resourceType=Thermostats", pel.sitename)).Type("form").AddCookie(pel.cookie).End()
 	if (errsTherms != nil) || (respTherms.StatusCode != 200) {
 		return fmt.Errorf("Error retrieving Thermostat IDs: %v", errsTherms)
 	}
-
 	var IDRequest thermIDRequest
 	decoder := json.NewDecoder(respTherms.Body)
 	if decodeError := decoder.Decode(&IDRequest); decodeError != nil {

--- a/driver/pelican/types/thermSchedule.go
+++ b/driver/pelican/types/thermSchedule.go
@@ -1,0 +1,232 @@
+// time: convert to iso 8601 standard (use pelican built in time zone value)
+// replace middlemen structs with json unmarshaling into free form struct + hard coded key
+
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/parnurzeal/gorequest"
+)
+
+// Login, Authentication, Thermostat ID Retrieval Structs
+type ThermostatRequest struct {
+	Request      string
+	Resources    []ThermostatResources
+	ResourceType string
+}
+
+type ThermostatResources struct {
+	Children     []ThermostatChild
+	GroupId      string
+	Id           string
+	Permissions  string
+	Schedule     string
+	ScheduleType string
+	Title        string
+}
+
+type ThermostatChild struct {
+	Id           string
+	Permissions  string
+	Schedule     string
+	ScheduleType string
+	Title        string
+}
+
+// Thermostat Settings Structs
+type ThermostatScheduleByIDRequest struct {
+	Epnum    float64
+	Id       string
+	Nodename string
+	Request  string
+	Status   int64
+	Userdata ThermostatScheduleByID
+}
+
+type ThermostatScheduleByID struct {
+	AllowDisableKeypad bool
+	Epnum              int64
+	Fan                string
+	Keypad             string
+	MultipleFan        bool
+	MultipleSystem     bool
+	Nodename           string
+	Repeat             string
+	RepeatDisplay      string
+	Reply              string
+	State              string
+	System             string
+	Status             int64
+}
+
+// Thermostat Schedule By Day Decoding Structs
+type ThermostatScheduleRequest struct {
+	ClientData ThermostatScheduleSetTimes `msgpack:"clientdata"`
+}
+
+type ThermostatScheduleSetTimes struct {
+	SetTimes []ThermostatScheduleSetTimesBlock `msgpack:"setTimes"`
+}
+
+type ThermostatScheduleSetTimesBlock struct {
+	Label         string `msgpack:"label"`
+	EntryIndex    int64  `msgpack:"entryIndex"`
+	StartValue    string `msgpack:"startValue"`
+	SystemDisplay string `msgpack:"systemDisplay"`
+	HeatSetting   int64  `msgpack:"heatSetting"`
+	CoolSetting   int64  `msgpack:"coolSetting"`
+	FanDisplay    string `msgpack:"fanDisplay"`
+}
+
+// Thermostat Schedule By Day Result Structs
+type ThermostatSchedule struct {
+	DaySchedules map[string]ThermostatDaySchedule
+}
+
+type ThermostatDaySchedule struct {
+	Blocks []ThermostatBlockSchedule
+}
+
+type ThermostatBlockSchedule struct {
+	Label         string
+	StartTime     string
+	HeatSetting   int64
+	CoolSetting   int64
+	SystemDisplay string
+}
+
+// Note: sitename parameter = 410soda
+func (pel *Pelican) GetSchedule(sitename string) (map[string]ThermostatSchedule, error) {
+	// Part 1: Retrieve Login Authentication Cookies
+	loginInfo := map[string]interface{}{
+		"username": pel.username,
+		"password": pel.password,
+		"sitename": sitename,
+	}
+	respLogin, _, errsLogin := gorequest.New().Post("https://410soda.officeclimatecontrol.net/#_loginPage").Type("form").Send(loginInfo).End()
+	if (errsLogin != nil) || (respLogin.StatusCode != 200) {
+		return nil, fmt.Errorf("Error logging into pelican website: %v", errsLogin)
+	}
+	cookies := (*http.Response)(respLogin).Cookies()
+	cookie := cookies[0]
+
+	// Part 2: Retrieve Thermostat IDs within this site
+	respTherms, _, errsTherms := gorequest.New().Get("https://410soda.officeclimatecontrol.net/ajaxSchedule.cgi?request=getResourcesExtended&resourceType=Thermostats").Type("form").AddCookie(cookie).End()
+	if (errsTherms != nil) || (respTherms.StatusCode != 200) {
+		return nil, fmt.Errorf("Error retrieving Thermostat IDs (AJAX Request): %v", errsTherms)
+	}
+	var result ThermostatRequest
+	decoder := json.NewDecoder(respTherms.Body)
+	if decodeError := decoder.Decode(&result); decodeError != nil {
+		return nil, fmt.Errorf("Failed to decode thermostat ID response JSON: %v\n", decodeError)
+	}
+	thermostatIDs := result.Resources[0].Children
+
+	var returnValue map[string]ThermostatSchedule
+	for _, child := range thermostatIDs {
+		var thermostatSchedule ThermostatSchedule
+
+		// Determine Repeat Cycle (Weekly, Daily, Weekday/Weekend)
+		repeatType, repeatTypeErr := getThermostatRepeatType(child.Id, cookie)
+		if repeatTypeErr != nil {
+			return nil, fmt.Errorf("Failed to determine repeat type for thermostat %v: %v", child.Id, repeatTypeErr)
+		}
+		repeatType = strings.TrimRight(repeatType, "\n")
+
+		// Build Schedule Based on Repeat Cycle Type
+		if repeatType == "Daily" {
+			schedule, scheduleError := getThermostatScheduleByDay(child.Id, cookie, "0")
+			if scheduleError != nil {
+				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v: %v", child.Id, scheduleError)
+			}
+			for _, day := range []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"} {
+				thermostatSchedule.DaySchedules[day] = schedule
+			}
+		} else if repeatType == "Weekly" {
+			for index, day := range []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"} {
+				schedule, scheduleError := getThermostatScheduleByDay(child.Id, cookie, strconv.Itoa(index))
+				if scheduleError != nil {
+					return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on %v (day %v): %v", child.Id, day, index, scheduleError)
+				}
+				thermostatSchedule.DaySchedules[day] = schedule
+			}
+		} else if repeatType == "Weekday/Weekend" {
+			weekend, weekendError := getThermostatScheduleByDay(child.Id, cookie, "0")
+			if weekendError != nil {
+				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on weekend (day 0): %v", child.Id, weekendError)
+			}
+			for _, day := range []string{"Sunday", "Saturday"} {
+				thermostatSchedule.DaySchedules[day] = weekend
+			}
+			weekday, weekdayError := getThermostatScheduleByDay(child.Id, cookie, "1")
+			if weekdayError != nil {
+				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on weekday (day 1): %v", child.Id, weekdayError)
+			}
+			for _, day := range []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday"} {
+				thermostatSchedule.DaySchedules[day] = weekday
+			}
+		} else {
+			return nil, fmt.Errorf("Failed to recognize repeat type of thermostat %v's schedule: %v", child.Id, repeatType)
+		}
+
+		returnValue[child.Id] = thermostatSchedule
+	}
+	return returnValue, nil
+}
+
+func getThermostatRepeatType(thermostatID string, cookie *http.Cookie) (string, error) {
+	var requestURL bytes.Buffer
+	requestURL.WriteString("https://410soda.officeclimatecontrol.net/ajaxThermostat.cgi?id=")
+	requestURL.WriteString(thermostatID)
+	requestURL.WriteString(":Thermostat&request=GetSchedule")
+
+	resp, _, errs := gorequest.New().Get(requestURL.String()).Type("form").AddCookie(cookie).End()
+	if errs != nil {
+		return "", fmt.Errorf("Failed to retrieve schedule settings (AJAX Request) for thermostat %v: %v", thermostatID, errs)
+	}
+	var result ThermostatScheduleByIDRequest
+	decoder := json.NewDecoder(resp.Body)
+	if decodeError := decoder.Decode(&result); decodeError != nil {
+		return "", fmt.Errorf("Failed to decode schedule settings (AJAX Request) for thermostat %v: %v", thermostatID, decodeError)
+	}
+	return result.Userdata.RepeatDisplay, nil
+}
+
+func getThermostatScheduleByDay(thermostatID string, cookie *http.Cookie, dayOfWeek string) (ThermostatDaySchedule, error) {
+	// Construct Request URL for Thermostat Schedule by Day of Week
+	var requestURL bytes.Buffer
+	requestURL.WriteString("https://410soda.officeclimatecontrol.net/thermDayEdit.cgi?section=json&nodename=")
+	requestURL.WriteString(thermostatID)
+	requestURL.WriteString("&epnum=1&dayofweek=")
+	requestURL.WriteString(dayOfWeek)
+
+	// Make Request, Decode into Response Struct
+	var daySchedule ThermostatDaySchedule
+	resp, _, errs := gorequest.New().Get(requestURL.String()).Type("form").AddCookie(cookie).End()
+	if errs != nil {
+		return daySchedule, fmt.Errorf("Failed to retrieve schedule for thermostat %v on day of week %v: %v", thermostatID, dayOfWeek, errs)
+	}
+	var result ThermostatScheduleRequest
+	decoder := json.NewDecoder(resp.Body)
+	if decodeError := decoder.Decode(&result); decodeError != nil {
+		return daySchedule, fmt.Errorf("Failed to decode schedule for thermostat %v on day of week %v: %v", thermostatID, dayOfWeek, decodeError)
+	}
+
+	// Transfer Response Struct Data into return struct
+	for _, block := range result.ClientData.SetTimes {
+		var returnBlock ThermostatBlockSchedule
+		returnBlock.Label = block.Label
+		returnBlock.CoolSetting = block.CoolSetting
+		returnBlock.HeatSetting = block.HeatSetting
+		returnBlock.StartTime = block.StartValue
+		returnBlock.SystemDisplay = block.SystemDisplay
+		daySchedule.Blocks = append(daySchedule.Blocks, returnBlock)
+	}
+	return daySchedule, nil
+}

--- a/driver/pelican/types/thermSchedule.go
+++ b/driver/pelican/types/thermSchedule.go
@@ -62,18 +62,18 @@ type scheduleTimeBlock struct {
 
 // Thermostat Schedule By Day Result Structs
 type ThermostatSchedule struct {
-	DaySchedules map[string]ThermostatDaySchedule
+	DaySchedules map[string]ThermostatDaySchedule `msgpack:"day_schedules"`
 }
 
 type ThermostatDaySchedule struct {
-	Blocks []ThermostatBlockSchedule
+	Blocks []ThermostatBlockSchedule `msgpack:blocks`
 }
 
 type ThermostatBlockSchedule struct {
-	CoolSetting float64
-	HeatSetting float64
-	System      string
-	Time        string
+	CoolSetting float64 `msgpack:"cool_setting"`
+	HeatSetting float64 `msgpack:"heat_setting"`
+	System      string  `msgpack:"system"`
+	Time        string  `msgpack:"time"`
 }
 
 var week = [...]string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}

--- a/driver/pelican/types/thermSchedule.go
+++ b/driver/pelican/types/thermSchedule.go
@@ -69,7 +69,7 @@ type ThermostatSchedule struct {
 
 // Struct containing a series of blocks that describes a one day schedule
 type ThermostatDaySchedule struct {
-	Blocks []ThermostatBlockSchedule `msgpack:blocks`
+	Blocks []ThermostatBlockSchedule `msgpack:"blocks"`
 }
 
 // Struct containing data defining the settings of each schedule block

--- a/driver/pelican/types/thermSchedule.go
+++ b/driver/pelican/types/thermSchedule.go
@@ -30,14 +30,14 @@ type thermIDChild struct {
 }
 
 // Thermostat Settings Structs
-type repeatTypeRequest struct {
-	Epnum    float64           `json:"epnum"`
-	Id       string            `json:"id"`
-	Nodename string            `json:"nodename"` // TODO(john-b-yang) Use nodename instead of id
-	Userdata repeatTypeWrapper `json:"userdata"`
+type settingsRequest struct {
+	Epnum    float64         `json:"epnum"`
+	Id       string          `json:"id"`
+	Nodename string          `json:"nodename"`
+	Userdata settingsWrapper `json:"userdata"`
 }
 
-type repeatTypeWrapper struct {
+type settingsWrapper struct {
 	Epnum    int64  `json:"epnum"`
 	Fan      string `json:"fan"`
 	Nodename string `json:"nodename"`
@@ -77,7 +77,7 @@ type ThermostatBlockSchedule struct {
 }
 
 func (pel *Pelican) GetSchedule(sitename string) (map[string]ThermostatSchedule, error) {
-	// Part 1: Retrieve Login Authentication Cookies
+	// Retrieve Login Authentication Cookies
 	loginInfo := map[string]interface{}{
 		"username": pel.username,
 		"password": pel.password,
@@ -90,75 +90,76 @@ func (pel *Pelican) GetSchedule(sitename string) (map[string]ThermostatSchedule,
 	cookies := (*http.Response)(respLogin).Cookies()
 	cookie := cookies[0]
 
-	// Part 2: Retrieve Thermostat IDs within this site
+	// Retrieve Thermostat IDs within given sitename
 	respTherms, _, errsTherms := gorequest.New().Get(fmt.Sprintf("https://%s.officeclimatecontrol.net/ajaxSchedule.cgi?request=getResourcesExtended&resourceType=Thermostats", sitename)).Type("form").AddCookie(cookie).End()
 	if (errsTherms != nil) || (respTherms.StatusCode != 200) {
 		return nil, fmt.Errorf("Error retrieving Thermostat IDs: %v", errsTherms)
 	}
 	var result thermIDRequest
 	decoder := json.NewDecoder(respTherms.Body)
-	// fmt.Printf("Thermostat Request URL: %v\n", respTherms.Request.URL)
-	// fmt.Printf("Thermostat Request: %v\n\n", respTherms.Body)
 	if decodeError := decoder.Decode(&result); decodeError != nil {
-		return nil, fmt.Errorf("Failed to decode thermostat ID response JSON: %v\n", decodeError)
+		return nil, fmt.Errorf("Failed to decode Thermostat ID response JSON: %v\n", decodeError)
 	}
 	thermostatIDs := result.Resources[0].Children
-	// fmt.Printf("Thermostat IDs: %v\n\n", thermostatIDs)
 
-	returnValue := make(map[string]ThermostatSchedule, len(thermostatIDs))
+	// Construct Weekly Schedules for each Thermostat ID
+	schedules := make(map[string]ThermostatSchedule, len(thermostatIDs))
 	for _, child := range thermostatIDs {
-		thermostatSchedule := ThermostatSchedule{}
-		thermostatSchedule.DaySchedules = make(map[string]ThermostatDaySchedule, 7)
+		week := []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}
+		thermSchedule := ThermostatSchedule{}
+		thermSchedule.DaySchedules = make(map[string]ThermostatDaySchedule, len(week))
 
-		repeatType, repeatTypeErr := getThermostatRepeatType(sitename, child.Id, cookie)
-		if repeatTypeErr != nil {
-			return nil, fmt.Errorf("Failed to determine repeat type for thermostat %v: %v", child.Id, repeatTypeErr)
+		// Retrieve Repeat Type (Daily, Weekly, Weekend/Weekday) and Nodename from Thermostat's Settings
+		settings, settingsErr := getSettings(sitename, child.Id, cookie)
+		if settingsErr != nil {
+			return nil, fmt.Errorf("Failed to determine repeat type for thermostat %v: %v", child.Id, settingsErr)
 		}
-		repeatType = strings.TrimRight(repeatType, "\n")
-		child.Id = strings.Split(child.Id, ":")[0] // TODO(john-b-yang) a bit hacky
+		repeatType := settings.Repeat
+		nodename := settings.Nodename
+		epnum := settings.Epnum
 
-		// Build Schedule Based on Repeat Cycle Type
+		// Build Schedule by Repeat Type
 		if repeatType == "Daily" {
-			schedule, scheduleError := getThermostatScheduleByDay("0", sitename, child.Id, cookie, pel.timezone)
+			schedule, scheduleError := getScheduleByDay(0, epnum, sitename, nodename, cookie, pel.timezone)
 			if scheduleError != nil {
-				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v: %v", child.Id, scheduleError)
+				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v: %v", nodename, scheduleError)
 			}
-			for _, day := range []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"} {
-				thermostatSchedule.DaySchedules[day] = schedule
+			for _, day := range week {
+				thermSchedule.DaySchedules[day] = schedule
 			}
 		} else if repeatType == "Weekly" {
-			for index, day := range []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"} {
-				schedule, scheduleError := getThermostatScheduleByDay(strconv.Itoa(index), sitename, child.Id, cookie, pel.timezone)
+			for index, day := range week {
+				schedule, scheduleError := getScheduleByDay(index, epnum, sitename, nodename, cookie, pel.timezone)
 				if scheduleError != nil {
-					return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on %v (day %v): %v", child.Id, day, index, scheduleError)
+					return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on %v (day %v): %v", nodename, day, index, scheduleError)
 				}
-				thermostatSchedule.DaySchedules[day] = schedule
+				thermSchedule.DaySchedules[day] = schedule
 			}
 		} else if repeatType == "Weekday/Weekend" {
-			weekend, weekendError := getThermostatScheduleByDay("0", sitename, child.Id, cookie, pel.timezone)
+			weekend, weekendError := getScheduleByDay(0, epnum, sitename, nodename, cookie, pel.timezone)
 			if weekendError != nil {
-				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on weekend (day 0): %v", child.Id, weekendError)
+				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on weekend (day 0): %v", nodename, weekendError)
 			}
 			for _, day := range []string{"Sunday", "Saturday"} {
-				thermostatSchedule.DaySchedules[day] = weekend
+				thermSchedule.DaySchedules[day] = weekend
 			}
-			weekday, weekdayError := getThermostatScheduleByDay("1", sitename, child.Id, cookie, pel.timezone)
+			weekday, weekdayError := getScheduleByDay(1, epnum, sitename, nodename, cookie, pel.timezone)
 			if weekdayError != nil {
-				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on weekday (day 1): %v", child.Id, weekdayError)
+				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on weekday (day 1): %v", nodename, weekdayError)
 			}
 			for _, day := range []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday"} {
-				thermostatSchedule.DaySchedules[day] = weekday
+				thermSchedule.DaySchedules[day] = weekday
 			}
 		} else {
-			return nil, fmt.Errorf("Failed to recognize repeat type of thermostat %v's schedule: %v", child.Id, repeatType)
+			return nil, fmt.Errorf("Failed to recognize repeat type of thermostat %v's schedule: %v", nodename, repeatType)
 		}
 
-		returnValue[child.Id] = thermostatSchedule
+		schedules[child.Id] = thermSchedule
 	}
-	return returnValue, nil
+	return schedules, nil
 }
 
-func getThermostatRepeatType(sitename, thermostatID string, cookie *http.Cookie) (string, error) {
+func getSettings(sitename, thermostatID string, cookie *http.Cookie) (settingsWrapper, error) {
 	var requestURL bytes.Buffer
 	requestURL.WriteString(fmt.Sprintf("https://%s.officeclimatecontrol.net/ajaxThermostat.cgi?id=", sitename))
 	requestURL.WriteString(thermostatID)
@@ -166,39 +167,41 @@ func getThermostatRepeatType(sitename, thermostatID string, cookie *http.Cookie)
 
 	resp, _, errs := gorequest.New().Get(requestURL.String()).Type("form").AddCookie(cookie).End()
 	if errs != nil {
-		return "", fmt.Errorf("Failed to retrieve schedule settings (AJAX Request) for thermostat %v: %v", thermostatID, errs)
+		return settingsWrapper{}, fmt.Errorf("Failed to retrieve schedule settings for thermostat %v: %v", thermostatID, errs)
 	}
-	var result repeatTypeRequest
+	var result settingsRequest
 	decoder := json.NewDecoder(resp.Body)
 	if decodeError := decoder.Decode(&result); decodeError != nil {
-		return "", fmt.Errorf("Failed to decode schedule settings (AJAX Request) for thermostat %v: %v", thermostatID, decodeError)
+		return settingsWrapper{}, fmt.Errorf("Failed to decode schedule settings for thermostat %v: %v", thermostatID, decodeError)
 	}
-	return result.Userdata.Repeat, nil
+	return result.Userdata, nil
 }
 
-func getThermostatScheduleByDay(dayOfWeek, sitename, thermostatID string, cookie *http.Cookie, timezone *time.Location) (ThermostatDaySchedule, error) {
+func getScheduleByDay(dayOfWeek int, epnum int64, sitename, thermostatID string, cookie *http.Cookie, timezone *time.Location) (ThermostatDaySchedule, error) {
 	// Construct Request URL for Thermostat Schedule by Day of Week
 	var requestURL bytes.Buffer
 	requestURL.WriteString(fmt.Sprintf("https://%s.officeclimatecontrol.net/thermDayEdit.cgi?section=json&nodename=", sitename))
 	requestURL.WriteString(thermostatID)
-	requestURL.WriteString("&epnum=1&dayofweek=")
-	requestURL.WriteString(dayOfWeek)
+	requestURL.WriteString("&epnum=")
+	requestURL.WriteString(strconv.FormatInt(epnum, 10))
+	requestURL.WriteString("&dayofweek=")
+	requestURL.WriteString(strconv.Itoa(dayOfWeek))
 
 	// Make Request, Decode into Response Struct
-	var daySchedule ThermostatDaySchedule
 	resp, _, errs := gorequest.New().Get(requestURL.String()).Type("form").AddCookie(cookie).End()
 	if errs != nil {
-		return daySchedule, fmt.Errorf("Failed to retrieve schedule for thermostat %v on day of week %v: %v", thermostatID, dayOfWeek, errs)
+		return ThermostatDaySchedule{}, fmt.Errorf("Failed to retrieve schedule for thermostat %v on day of week %v: %v", thermostatID, dayOfWeek, errs)
 	}
 	var result scheduleRequest
 	// fmt.Println(requestURL.String())
 	// fmt.Printf("Get Schedule By Day Response: %v\n", resp.Body)
 	decoder := json.NewDecoder(resp.Body)
 	if decodeError := decoder.Decode(&result); decodeError != nil {
-		return daySchedule, fmt.Errorf("Failed to decode schedule for thermostat %v on day of week %v: %v", thermostatID, dayOfWeek, decodeError)
+		return ThermostatDaySchedule{}, fmt.Errorf("Failed to decode schedule for thermostat %v on day of week %v: %v", thermostatID, dayOfWeek, decodeError)
 	}
 
 	// Transfer Response Struct Data into return struct
+	var daySchedule ThermostatDaySchedule
 	for _, block := range result.ClientData.SetTimes {
 		var returnBlock ThermostatBlockSchedule
 		returnBlock.CoolSetting = block.CoolSetting

--- a/driver/pelican/types/thermSchedule.go
+++ b/driver/pelican/types/thermSchedule.go
@@ -67,7 +67,7 @@ type ThermostatSchedule struct {
 	DaySchedules map[string]ThermostatDaySchedule `msgpack:"day_schedules"`
 }
 
-// Struct containing a series of blocks that describes a day long schedule
+// Struct containing a series of blocks that describes a one day schedule
 type ThermostatDaySchedule struct {
 	Blocks []ThermostatBlockSchedule `msgpack:blocks`
 }

--- a/driver/pelican/types/thermSchedule.go
+++ b/driver/pelican/types/thermSchedule.go
@@ -60,15 +60,19 @@ type scheduleTimeBlock struct {
 	System      string  `json:"systemDisplay"`
 }
 
-// Thermostat Schedule By Day Result Structs
+// Thermostat Schedule Structs
+
+// Struct mapping each day of the week to its daily schedule
 type ThermostatSchedule struct {
 	DaySchedules map[string]ThermostatDaySchedule `msgpack:"day_schedules"`
 }
 
+// Struct containing a series of blocks that describes a day long schedule
 type ThermostatDaySchedule struct {
 	Blocks []ThermostatBlockSchedule `msgpack:blocks`
 }
 
+// Struct containing data defining the settings of each schedule block
 type ThermostatBlockSchedule struct {
 	CoolSetting float64 `msgpack:"cool_setting"`
 	HeatSetting float64 `msgpack:"heat_setting"`

--- a/driver/pelican/types/thermSchedule.go
+++ b/driver/pelican/types/thermSchedule.go
@@ -119,7 +119,7 @@ func (pel *Pelican) GetSchedule(sitename string) (map[string]ThermostatSchedule,
 
 		// Build Schedule Based on Repeat Cycle Type
 		if repeatType == "Daily" {
-			schedule, scheduleError := getThermostatScheduleByDay("0", sitename, child.Id, cookie, timezone)
+			schedule, scheduleError := getThermostatScheduleByDay("0", sitename, child.Id, cookie, pel.timezone)
 			if scheduleError != nil {
 				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v: %v", child.Id, scheduleError)
 			}
@@ -128,21 +128,21 @@ func (pel *Pelican) GetSchedule(sitename string) (map[string]ThermostatSchedule,
 			}
 		} else if repeatType == "Weekly" {
 			for index, day := range []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"} {
-				schedule, scheduleError := getThermostatScheduleByDay(strconv.Itoa(index), sitename, child.Id, cookie, timezone)
+				schedule, scheduleError := getThermostatScheduleByDay(strconv.Itoa(index), sitename, child.Id, cookie, pel.timezone)
 				if scheduleError != nil {
 					return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on %v (day %v): %v", child.Id, day, index, scheduleError)
 				}
 				thermostatSchedule.DaySchedules[day] = schedule
 			}
 		} else if repeatType == "Weekday/Weekend" {
-			weekend, weekendError := getThermostatScheduleByDay("0", sitename, child.Id, cookie, timezone)
+			weekend, weekendError := getThermostatScheduleByDay("0", sitename, child.Id, cookie, pel.timezone)
 			if weekendError != nil {
 				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on weekend (day 0): %v", child.Id, weekendError)
 			}
 			for _, day := range []string{"Sunday", "Saturday"} {
 				thermostatSchedule.DaySchedules[day] = weekend
 			}
-			weekday, weekdayError := getThermostatScheduleByDay("1", sitename, child.Id, cookie, timezone)
+			weekday, weekdayError := getThermostatScheduleByDay("1", sitename, child.Id, cookie, pel.timezone)
 			if weekdayError != nil {
 				return nil, fmt.Errorf("Error retrieving schedule for thermostat %v on weekday (day 1): %v", child.Id, weekdayError)
 			}


### PR DESCRIPTION
Created a new file thermSchedule.go within the types directory of the pelican driver code.

The Pelican Thermostat API does not have a way to retrieve thermostat schedule data. ThermSchedule.go sends AJAX Requests to the climate control website to scrape the desired data from the website itself. The thermSchedule.go exposes one method, getSchedule, that performs this task. Within main.go and params.yml, polling code and an interval parameter has been added. This code is very similar to the existing status and demand response polling code.